### PR TITLE
Extract HLS service, fix VOD URL path, add reachability cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ frigate-review-accelerator/
         indexer.py            # Filesystem walker → segments table
         preview_generator.py  # ffmpeg thumbnail extractor
         worker.py             # Background task: index → on-demand → recency → background
+        event_sync.py         # Frigate event poller → events table
+        hls.py                # Frigate VOD URL construction + reachability cache
     requirements.txt
     .env                      # Not in git — copy from .env.example
   frontend/
@@ -174,69 +176,57 @@ CORS_ORIGINS=["http://localhost:5173"]
 - 0 previews generated (worker running, recency pass active)
 - Backend stable, frontend stable
 - Admin panel (⚙ Ops button, bottom-right) operational
+- HLS VOD playback via Frigate's /api/vod/ API (hls.js in frontend)
+- MP4 segment fallback when Frigate VOD unreachable
 
 -----
 
-## Known bugs to fix (v2)
+## Known bugs — v2 (all fixed)
 
-### 1. Playback cursor drift  ← fix this first
+All v2 bugs are resolved. See git log for details.
 
-`VideoPlayer.handleEnded` auto-advances segments by swapping video src directly.
-`playbackTarget` in `App.jsx` is never updated. After crossing a segment boundary,
-`absoluteTs = playbackTarget.segment_start_ts + video.currentTime` uses the old
-segment’s start_ts and the timeline cursor drifts by one full segment duration.
+## Known issues — v3
 
-**Fix:** Add `onSegmentAdvance(nextSegmentId)` prop to VideoPlayer. On segment end,
-call it instead of swapping src. In App.jsx fetch `/api/playback` for the new
-segment and update `playbackTarget` state.
+### 1. HLS seek offset edge case (low priority)
 
-### 2. Full filesystem scan every 30s
+In VideoPlayer.jsx the seek offset into the HLS window is capped at 30s:
+  const seekOffset = Math.min(playbackTarget.offset_sec, 30)
+This is correct because _build_hls_url starts the window at max(seg_start, requested_ts - 30).
+Edge case: if requested_ts - seg_start > 30, offset_sec > 30 and the cap kicks in,
+placing the seek slightly before the requested position. Frigate segments are ~10s
+so this never triggers in practice, but it’s worth noting.
 
-`scan_recordings_dir` does `root.rglob("*.mp4")` on every worker cycle.
-`scan_state` table exists but is never written to.
+### 2. HLS reachability cache is process-local
 
-**Fix:** Write `last_scanned_ts` per camera to `scan_state` after each scan.
-Use `os.scandir` + `st_mtime` filtering on subsequent cycles. Full rglob only
-on first run (empty `scan_state`).
+_hls_reachable_cache lives in the uvicorn process. Do NOT run uvicorn with
+--workers > 1 (this was already a constraint for the demand queue). This is documented.
 
-### 3. One ffmpeg subprocess per preview frame
+### 3. Frigate VOD URL uses /api/vod/ path
 
-`_extract_frame_at_offset` is called in a loop. 5 subprocesses per segment,
-~7.5M total at current scale.
-
-**Fix:** Single ffmpeg call per segment using the `select` filter. Write to
-temp dir, rename to aligned bucket timestamps, move to final location.
-Keep single-frame as fallback.
-
-### 4. Minor
-
-- `asyncio.get_event_loop()` → `asyncio.get_running_loop()` (deprecated 3.10+)
-- CORS origins hardcoded in main.py → use `settings.cors_origins`
-- `logs/` and `.pids/` missing from `.gitignore`
-- Admin panel restart button gets stuck when uvicorn kills itself mid-stream
-  (fetch errors before `done` SSE fires) — show reconnect state + poll `/api/health`
+Frigate exposes VOD at `{frigate_api_url}/api/vod/{camera}/start/{t}/end/{t}`.
+The path `/vod/` (without /api/ prefix) returns nginx 400. _build_hls_url in
+hls.py uses the correct /api/vod/ path.
 
 -----
 
-## Planned v2 features
+## Planned v3 features
 
-1. **Timeline zoom** — scroll wheel zooms time range centred on cursor. Min 15m, max 7d.
-   Add `onRangeChange(newStart, newEnd)` callback. Range state stays in App.jsx.
-1. **Frigate event sync** — new `backend/app/services/event_sync.py`.
-   Poll `GET {frigate_api}/api/events`, upsert into `events` table,
-   track `last_event_sync_ts` in `scan_state`. Run in worker after indexing.
-   This makes the event overlay markers on the timeline actually populate.
-1. **Per-camera preview progress** — `GET /api/preview/progress` returning
-   `[{camera, total_segments, previews_done, pending_recent, pending_historical}]`.
-   Progress bars in AdminPanel status tab.
-1. **Preview retention cleanup** — delete previews older than `preview_retention_days`
-   (default 30). Background job, runs once daily in small batches.
+1. **HLS window extension** — When playback reaches within 60s of the end of the
+   current HLS window, fetch a new PlaybackTarget centered on the current absoluteTs
+   and reload the hls.js source. This gives effectively unlimited continuous playback.
+   Add onWindowExhausting(currentTs) callback from VideoPlayer → App.jsx.
+
+2. **Frigate event sync paging** — event_sync.py fetches one page of 100 events.
+   If a camera has >100 new events since last sync, older ones are silently skipped.
+   Fix: paginate using Frigate's after/before params until response length < _LIMIT.
+
+3. **Preview retention verification** — At 2s intervals, 9 cameras, 30 days:
+   ~175GB of preview JEPGs. Confirm delete_old_previews runs and verify disk usage
+   is stable before increasing preview_retention_days.
 
 -----
 
 ## Testing
-
-No tests exist yet. When writing tests:
 
 ```bash
 # Run all tests
@@ -249,7 +239,7 @@ cd backend && pytest tests/unit/test_preview.py::test_quantize_ts_alignment -v
 cd backend && pytest --cov=app tests/
 ```
 
-Planned structure:
+Test structure:
 
 ```
 backend/tests/
@@ -257,25 +247,17 @@ backend/tests/
     test_indexer.py        # parse_segment_path, _global_bucket_timestamps
     test_preview.py        # _quantize_ts, _bucket_path — the O(1) invariants
     test_timeline.py       # _compute_gaps, _compute_activity, coverage_pct
+    test_scan_state.py     # incremental scan state per camera
   integration/
     test_api.py            # httpx AsyncClient against real in-memory SQLite
+    test_playback_hls.py   # HLS URL construction + reachability cache
     conftest.py            # fixtures
-```
-
-Most critical tests (write these first):
-
-```python
-test_quantize_ts_alignment()     # bucket math must be globally aligned — everything depends on this
-test_global_bucket_timestamps()  # boundary conditions, empty range
-test_parse_segment_path_valid()  # indexer foundation
-test_gap_detection()             # gaps drive timeline rendering
-test_playback_gap_snapping()     # ts in gap → nearest segment, not 404
-test_preview_no_db_on_hit()      # mock get_db — assert never called on cache hit
 ```
 
 Use `pytest` + `pytest-asyncio` + `httpx.AsyncClient`.
 Use SQLite `:memory:` for integration tests.
 Mock `subprocess.run` at the boundary in unit tests — never call real ffmpeg.
+Patch `app.services.hls.httpx.AsyncClient` when mocking Frigate reachability.
 
 -----
 

--- a/backend/app/routers/preview.py
+++ b/backend/app/routers/preview.py
@@ -32,7 +32,7 @@ from app.config import settings
 from app.models.database import get_db
 from app.models.schemas import CameraPreviewStatus, PreviewFrame, PreviewStrip
 from app.services.worker import enqueue_preview_request
-from app.routers.timeline import _build_hls_url, _resolve_hls_url
+from app.services.hls import _build_hls_url, _resolve_hls_url
 
 router = APIRouter(prefix="/api", tags=["preview"])
 log = logging.getLogger(__name__)

--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -12,11 +12,11 @@ All timestamp parameters are Unix timestamps (float).
 import math
 from collections import defaultdict
 
-import httpx
 from fastapi import APIRouter, Query, HTTPException
 
 from app.config import settings
 from app.models.database import get_db
+from app.services.hls import _build_hls_url, _resolve_hls_url
 from app.models.schemas import (
     ActivityBucket,
     CameraInfo,
@@ -36,39 +36,6 @@ router = APIRouter(prefix="/api", tags=["timeline"])
 # Gaps shorter than this are segment boundary jitter, not real outages.
 MIN_GAP_SEC = 2.0
 
-
-def _build_hls_url(camera: str, requested_ts: float, seg_start: float) -> str:
-    """Construct a Frigate VOD HLS playlist URL.
-
-    Pure function — no DB calls, no async, no side effects.
-    Window starts 30s before requested_ts (or at seg_start, whichever is later)
-    and spans frigate_vod_window_sec seconds.
-    """
-    window_start = max(seg_start, requested_ts - 30)
-    window_end = window_start + settings.frigate_vod_window_sec
-    return (
-        f"{settings.frigate_api_url}/vod/{camera}"
-        f"/start/{window_start:.0f}/end/{window_end:.0f}"
-    )
-
-
-async def _resolve_hls_url(camera: str, requested_ts: float, seg_start: float) -> str | None:
-    """Build the HLS URL and verify Frigate VOD is reachable.
-
-    Returns the URL if Frigate responds 2xx, None otherwise.
-    Never raises — any failure yields None so /api/playback never breaks.
-    """
-    if not settings.frigate_vod_enabled:
-        return None
-    url = _build_hls_url(camera, requested_ts, seg_start)
-    try:
-        async with httpx.AsyncClient(timeout=2.0) as client:
-            r = await client.head(url)
-            if r.status_code < 300:
-                return url
-    except Exception:
-        pass
-    return None
 
 
 def _compute_gaps(

--- a/backend/app/services/hls.py
+++ b/backend/app/services/hls.py
@@ -1,0 +1,69 @@
+"""Frigate VOD URL construction and reachability cache.
+
+Pure utilities shared by timeline.py and preview.py.
+_build_hls_url is a pure function — no DB calls, no async, no side effects.
+_resolve_hls_url does a HEAD request on first use per camera, then caches
+reachability for _HLS_CACHE_TTL_SEC seconds to avoid per-seek latency.
+"""
+
+import time as _time
+
+import httpx
+
+from app.config import settings
+
+# ---------------------------------------------------------------------------
+# Reachability cache
+# ---------------------------------------------------------------------------
+_hls_reachable_cache: dict[str, float] = {}
+_HLS_CACHE_TTL_SEC = 30.0
+
+
+# ---------------------------------------------------------------------------
+# URL construction
+# ---------------------------------------------------------------------------
+def _build_hls_url(camera: str, requested_ts: float, seg_start: float) -> str:
+    """Construct a Frigate VOD HLS playlist URL.
+
+    Pure function — no DB calls, no async, no side effects.
+    Window starts 30s before requested_ts (or at seg_start, whichever is later)
+    and spans frigate_vod_window_sec seconds.
+    """
+    window_start = max(seg_start, requested_ts - 30)
+    window_end = window_start + settings.frigate_vod_window_sec
+    return (
+        f"{settings.frigate_api_url}/api/vod/{camera}"
+        f"/start/{window_start:.0f}/end/{window_end:.0f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reachability check
+# ---------------------------------------------------------------------------
+async def _resolve_hls_url(camera: str, requested_ts: float, seg_start: float) -> str | None:
+    """Build the HLS URL and verify Frigate VOD is reachable.
+
+    Returns the URL if Frigate responds 2xx, None otherwise.
+    Never raises — any failure yields None so /api/playback never breaks.
+
+    Uses a per-camera reachability cache (_hls_reachable_cache) with a
+    _HLS_CACHE_TTL_SEC TTL to avoid a HEAD request on every seek.  Cache is
+    NOT invalidated on failure — a failed check simply lets the TTL expire
+    naturally, avoiding thrashing when Frigate is flapping.
+    """
+    if not settings.frigate_vod_enabled:
+        return None
+    now = _time.time()
+    if _hls_reachable_cache.get(camera, 0) + _HLS_CACHE_TTL_SEC > now:
+        # Cache hit — Frigate was reachable recently, skip the HEAD request
+        return _build_hls_url(camera, requested_ts, seg_start)
+    url = _build_hls_url(camera, requested_ts, seg_start)
+    try:
+        async with httpx.AsyncClient(timeout=2.0) as client:
+            r = await client.head(url)
+            if r.status_code < 300:
+                _hls_reachable_cache[camera] = now
+                return url
+    except Exception:
+        pass
+    return None

--- a/backend/tests/integration/test_playback_hls.py
+++ b/backend/tests/integration/test_playback_hls.py
@@ -43,7 +43,7 @@ async def test_playback_hls_url_present(client, test_app, monkeypatch):
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.head = AsyncMock(return_value=mock_response)
 
-    with patch("app.routers.timeline.httpx.AsyncClient", return_value=mock_client):
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
         resp = await client.get(
             "/api/playback",
             params={"camera": "hls-test-cam", "ts": start_ts + 5.0},
@@ -53,7 +53,7 @@ async def test_playback_hls_url_present(client, test_app, monkeypatch):
     data = resp.json()
     assert "hls_url" in data
     assert data["hls_url"] is not None
-    assert "/vod/hls-test-cam/start/" in data["hls_url"]
+    assert "/api/vod/hls-test-cam/start/" in data["hls_url"]
     assert config.settings.frigate_api_url in data["hls_url"]
 
 
@@ -73,7 +73,7 @@ async def test_playback_hls_url_none_when_frigate_down(client, test_app, monkeyp
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.head = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
 
-    with patch("app.routers.timeline.httpx.AsyncClient", return_value=mock_client):
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
         resp = await client.get(
             "/api/playback",
             params={"camera": "hls-down-cam", "ts": start_ts + 5.0},
@@ -113,7 +113,7 @@ async def test_segment_info_endpoint(client, test_app):
     mock_client.__aexit__ = AsyncMock(return_value=False)
     mock_client.head = AsyncMock(return_value=mock_response)
 
-    with patch("app.routers.timeline.httpx.AsyncClient", return_value=mock_client):
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
         resp = await client.get(f"/api/segment/{seg_id}/info")
 
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- **Extract `hls.py` service** — `_build_hls_url` and `_resolve_hls_url` moved from `timeline.py` into a new `backend/app/services/hls.py` module. Both `preview.py` and `timeline.py` now import from the shared service, eliminating the cross-router import.
- **Fix VOD URL path** — the bare `/vod/` path returns nginx 400; corrected to `/api/vod/` which is what Frigate actually exposes.
- **Add reachability cache** — `_resolve_hls_url` now caches per-camera reachability for 30 seconds, so rapid timeline scrubbing doesn't fire a HEAD request to Frigate on every seek event.
- **Update test patches** — test mocks updated from `app.routers.timeline.httpx.AsyncClient` to `app.services.hls.httpx.AsyncClient` to match the new module path.
- **CLAUDE.md** — v2 bugs marked resolved, v3 known issues and planned features documented, test structure updated.

## Test plan

- [ ] `cd backend && pytest tests/integration/test_playback_hls.py -v` — all 4 HLS tests pass
- [ ] `cd backend && pytest` — full suite passes
- [ ] Manually verify HLS playback works in the UI against the running Frigate instance
- [ ] Confirm `hls_url` is `null` in `/api/playback` response when Frigate is stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)