### PR TITLE
Fix: timeline preview image does not update during scrubbing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -295,6 +295,7 @@ export default function App() {
               events={timelineData?.events || []}
               activity={timelineData?.activity || []}
               frames={previewFrames}
+              camera={selectedCamera}
               cursorTs={cursorTs}
               onScrub={handleScrub}
               onSeek={handleSeek}

--- a/frontend/src/components/SplitView.jsx
+++ b/frontend/src/components/SplitView.jsx
@@ -124,6 +124,7 @@ function CameraPane({
           events={timelineData?.events || []}
           activity={timelineData?.activity || []}
           frames={previewFrames}
+          camera={camera}
           cursorTs={activeCursor}
           onScrub={handleScrub}
           onSeek={handleSeek}

--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -115,6 +115,7 @@ export default function Timeline({
   events = [],
   activity = [],
   frames = [],
+  camera,
   cursorTs,
   onScrub,
   onSeek,
@@ -379,9 +380,9 @@ export default function Timeline({
   // ───────────────────────────────────────────────
   const displayTs = scrubTs ?? hoverTs ?? cursorTs;
   const nearestFrame = displayTs != null ? findNearestFrame(frames, displayTs) : null;
-  const previewImg = nearestFrame
-    ? imageCacheRef.current.get(nearestFrame.url)
-    : null;
+  const previewUrl = (camera && displayTs != null)
+    ? `/api/preview/${camera}/${displayTs}`
+    : nearestFrame?.url ?? null;
 
   const showPreview = scrubTs != null || cursorTs != null;
 
@@ -402,16 +403,14 @@ export default function Timeline({
           transition: 'height 0.15s ease',
         }}
       >
-        {showPreview && previewImg && previewImg.complete ? (
+        {showPreview && previewUrl ? (
           <img
-            src={previewImg.src}
+            key={previewUrl}
+            src={previewUrl}
             alt="Preview"
             style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            onError={(e) => { e.currentTarget.style.display = 'none'; }}
           />
-        ) : showPreview ? (
-          <span style={{ color: '#555', fontSize: 13 }}>
-            {displayTs != null ? 'Loading...' : ''}
-          </span>
         ) : null}
         {showPreview && displayTs != null && (
           <div


### PR DESCRIPTION
## Problem
Scrubbing the timeline showed a static image that never updated. Two bugs:

1. Timeline.jsx resolved preview images from the pre-fetched strip array
   (fetched once on load) rather than calling the hot-path
   `/api/preview/{camera}/{ts}` endpoint during scrubbing. On a sparse
   strip every timestamp resolved to the same nearest frame.

2. The render condition `previewImg.complete` silently suppressed images
   that hadn't finished loading at render time, with no callback to
   re-render on load completion.

## Fix
- Add a `camera` prop to Timeline and build the preview URL directly from
  the current timestamp, pointing at the backend's O(1) bucket endpoint.
- Drop the `.complete` check. Use `key={previewUrl}` to force a fresh
  `<img>` mount on each scrub position, and `onError` to silently hide
  missing frames.
- Pass `camera` from App.jsx (single-camera view) and SplitView.jsx.

## What stays the same
- `useImageCache` and `findNearestFrame` are retained. The cache still
  warms the browser HTTP cache from the strip data; findNearestFrame
  provides a fallback URL when camera prop is absent.
- No backend changes required.