### PR TITLE
Fix: black flash between preview frames during timeline scrubbing

### DIFF
--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -386,6 +386,43 @@ export default function Timeline({
 
   const showPreview = scrubTs != null || cursorTs != null;
 
+  // Last successfully loaded preview URL — stays visible until the next
+  // frame is ready. Avoids the black flash caused by unmounting the old
+  // <img> before the new one has loaded.
+  const [displayedUrl, setDisplayedUrl] = useState(null);
+  const loadingImgRef = useRef(null);
+
+  useEffect(() => {
+    if (!previewUrl) return;
+
+    if (loadingImgRef.current) {
+      loadingImgRef.current.onload = null;
+      loadingImgRef.current.onerror = null;
+      loadingImgRef.current = null;
+    }
+
+    const img = new Image();
+    loadingImgRef.current = img;
+
+    img.onload = () => {
+      setDisplayedUrl(previewUrl);
+      loadingImgRef.current = null;
+    };
+    img.onerror = () => {
+      // Do not update displayedUrl — keep the last good frame visible
+      // rather than going blank when a frame has not been generated yet.
+      loadingImgRef.current = null;
+    };
+
+    img.src = previewUrl;
+
+    return () => {
+      // Cancel on cleanup (rapid scrubbing or unmount)
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [previewUrl]);
+
   return (
     <div ref={containerRef} style={{ width: '100%', userSelect: 'none' }}>
       {/* Preview thumbnail */}
@@ -403,13 +440,11 @@ export default function Timeline({
           transition: 'height 0.15s ease',
         }}
       >
-        {showPreview && previewUrl ? (
+        {showPreview && displayedUrl ? (
           <img
-            key={previewUrl}
-            src={previewUrl}
+            src={displayedUrl}
             alt="Preview"
             style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
-            onError={(e) => { e.currentTarget.style.display = 'none'; }}
           />
         ) : null}
         {showPreview && displayTs != null && (


### PR DESCRIPTION
## Problem
After the previous preview fix, scrubbing the timeline caused a black
flash between every frame. The `key={previewUrl}` prop forced React to
unmount and remount the `<img>` element on each scrub position, creating
a guaranteed blank gap while the new image loaded.

## Fix
Load new preview frames in the background using `new Image()`. The
currently displayed image stays visible until the background load
completes, then `displayedUrl` state is updated and React swaps the
`src` in-place on the existing DOM node — no unmount, no flash.

Rapid scrubbing is handled by cancelling any in-flight load before
starting the next one, so stale frames cannot arrive late and flicker in.

Missing frames (404 from backend) are handled by the onerror callback
simply not updating `displayedUrl`, so the last good frame holds rather
than going blank.

## Changes
- `frontend/src/components/Timeline.jsx` only
- No backend changes
- No changes to App.jsx or SplitView.jsx