### PR TITLE
feat(frontend): vertical timeline strip, shared viewer, goto datetime

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,19 @@
 /**
  * App — Main application shell.
  *
- * v2 additions:
- *   - onSegmentAdvance: fetches /api/playback for next segment → fixes cursor drift
- *   - Timeline zoom: scroll-wheel zooms range, clamped to 15m–7d
- *   - Split view: select 2+ cameras → SplitView component
+ * v3 layout:
+ *   - 100vh flex-column, no scroll
+ *   - Single-camera: 2-column layout (VideoPlayer left, VerticalTimeline right)
+ *   - Hover on VerticalTimeline shows preview overlay on VideoPlayer (hoverTs)
+ *   - Click on VerticalTimeline commits playback (handleSeek)
+ *   - "Go to" datetime input in controls bar (single-camera mode only)
+ *   - SplitView path unchanged
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import CameraSelector from './components/CameraSelector.jsx';
 import Timeline from './components/Timeline.jsx';
+import VerticalTimeline from './components/VerticalTimeline.jsx';
 import VideoPlayer from './components/VideoPlayer.jsx';
 import AdminPanel from './components/AdminPanel.jsx';
 import SplitView from './components/SplitView.jsx';
@@ -26,17 +30,23 @@ import { todayStartTs, nowTs, formatDateTime } from './utils/time.js';
 const MIN_RANGE_SEC = 15 * 60;
 const MAX_RANGE_SEC = 7 * 24 * 3600;
 
+/** Format a Unix timestamp for a datetime-local input value. */
+function toDatetimeLocal(ts) {
+  const d = new Date(ts * 1000);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
 export default function App() {
   const [cameras, setCameras] = useState([]);
-  // Single-camera mode state
   const [selectedCamera, setSelectedCamera] = useState(null);
-  // Multi-camera (split view) state
   const [selectedCameras, setSelectedCameras] = useState([]);
   const [multiMode, setMultiMode] = useState(false);
 
   const [timelineData, setTimelineData] = useState(null);
   const [previewFrames, setPreviewFrames] = useState([]);
   const [cursorTs, setCursorTs] = useState(null);
+  const [hoverTs, setHoverTs] = useState(null);
   const [playbackTarget, setPlaybackTarget] = useState(null);
   const [health, setHealth] = useState(null);
   const [error, setError] = useState(null);
@@ -44,6 +54,8 @@ export default function App() {
 
   const [rangeStart, setRangeStart] = useState(todayStartTs());
   const [rangeEnd, setRangeEnd] = useState(nowTs());
+
+  const [gotoValue, setGotoValue] = useState(() => toDatetimeLocal(nowTs()));
 
   // ─── Init: load cameras + health ───
   useEffect(() => {
@@ -107,15 +119,22 @@ export default function App() {
     setRangeEnd(newEnd);
   }, []);
 
-  // ─── Scrub handler: images only, no video ───
+  // ─── Scrub handler: sets hover position + moves cursor line ───
   const handleScrub = useCallback((ts) => {
+    setHoverTs(ts);
     setCursorTs(ts);
   }, []);
 
-  // ─── Seek handler: calls /api/playback, triggers video ───
+  // ─── Scrub end: clear hover (cursor stays at last position) ───
+  const handleScrubEnd = useCallback(() => {
+    setHoverTs(null);
+  }, []);
+
+  // ─── Seek handler: commits playback, clears hover ───
   const handleSeek = useCallback(
     async (ts) => {
       if (!selectedCamera) return;
+      setHoverTs(null);
       setCursorTs(ts);
 
       try {
@@ -130,17 +149,10 @@ export default function App() {
   );
 
   // ─── Segment advance: fixes cursor drift bug ───
-  // Called by VideoPlayer when a segment ends and it auto-advances.
-  // We fetch the new PlaybackTarget so segment_start_ts stays accurate.
   const handleSegmentAdvance = useCallback(
     async (nextSegmentId) => {
       if (!selectedCamera) return;
       try {
-        // Fetch playback at the very start of the next segment (offset 0)
-        const nextStreamUrl = `/api/segment/${nextSegmentId}/stream`;
-        // We need the segment's start_ts to compute cursor position correctly.
-        // The cleanest path is to call /api/playback with the next segment's start_ts.
-        // Since we don't have it here, derive it from current playbackTarget.end_ts.
         const nextTs = playbackTarget?.segment_end_ts ?? (cursorTs ?? 0);
         const target = await fetchPlaybackTarget(selectedCamera, nextTs + 0.1);
         setPlaybackTarget(target);
@@ -158,6 +170,7 @@ export default function App() {
   const handleCameraChange = useCallback((name) => {
     setSelectedCamera(name);
     setCursorTs(null);
+    setHoverTs(null);
     setPlaybackTarget(null);
     setTimelineData(null);
     setPreviewFrames([]);
@@ -186,6 +199,22 @@ export default function App() {
     setRangeStart(end - hours * 3600);
     setRangeEnd(end);
   }, []);
+
+  // ─── "Go to" handler ───
+  const handleGoto = useCallback(() => {
+    if (!gotoValue) return;
+    const ts = new Date(gotoValue).getTime() / 1000;
+    if (isNaN(ts)) return;
+    const halfRange = (rangeEnd - rangeStart) / 2;
+    handleRangeChange(ts - halfRange, ts + halfRange);
+    handleSeek(ts);
+  }, [gotoValue, rangeStart, rangeEnd, handleRangeChange, handleSeek]);
+
+  // ─── Derive scrub preview URL ───
+  const activePreviewUrl =
+    hoverTs != null && selectedCamera
+      ? `/api/preview/${selectedCamera}/${hoverTs}`
+      : null;
 
   // ─── Render ───
   if (loading) {
@@ -256,6 +285,30 @@ export default function App() {
           {multiMode ? '◈ Single' : '◈ Split'}
         </button>
 
+        {/* "Go to" group — single-camera mode only */}
+        {!multiMode && (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+            <span style={{ color: '#666', fontSize: 12 }}>Go to:</span>
+            <input
+              type="datetime-local"
+              value={gotoValue}
+              onChange={(e) => setGotoValue(e.target.value)}
+              style={{
+                colorScheme: 'dark',
+                background: '#1a1d27',
+                border: '1px solid #333',
+                color: '#aaa',
+                padding: '3px 6px',
+                borderRadius: 4,
+                fontSize: 12,
+              }}
+            />
+            <button onClick={handleGoto} style={styles.rangeBtn}>
+              Go
+            </button>
+          </div>
+        )}
+
         <div style={styles.rangeButtons}>
           {[1, 4, 8, 24].map((h) => (
             <button key={h} onClick={() => setRange(h)} style={styles.rangeBtn}>
@@ -263,58 +316,85 @@ export default function App() {
             </button>
           ))}
         </div>
-
-        {cursorTs && !multiMode && (
-          <span style={styles.timestamp}>{formatDateTime(cursorTs)}</span>
-        )}
       </div>
 
-      {/* Main content: split view or single view */}
+      {/* Main content */}
       {multiMode && selectedCameras.length >= 2 ? (
+        /* ── Split view (unchanged) ── */
         <SplitView
           cameras={selectedCameras}
           rangeStart={rangeStart}
           rangeEnd={rangeEnd}
           onRangeChange={handleRangeChange}
         />
-      ) : (
-        <>
-          <VideoPlayer
-            playbackTarget={playbackTarget}
-            camera={selectedCamera}
-            onTimeUpdate={handlePlaybackTimeUpdate}
-            onSegmentAdvance={handleSegmentAdvance}
-          />
+      ) : !multiMode ? (
+        /* ── Single-camera: 2-column layout ── */
+        <div style={styles.singleLayout}>
+          {/* Left: video viewer column */}
+          <div style={styles.viewerCol}>
+            <div style={{ flex: 1, minHeight: 0 }}>
+              <VideoPlayer
+                playbackTarget={playbackTarget}
+                camera={selectedCamera}
+                onTimeUpdate={handlePlaybackTimeUpdate}
+                onSegmentAdvance={handleSegmentAdvance}
+                scrubPreviewUrl={activePreviewUrl}
+              />
+            </div>
 
-          <div style={{ marginTop: 12 }}>
-            <Timeline
-              startTs={rangeStart}
-              endTs={rangeEnd}
-              segments={timelineData?.segments || []}
-              gaps={timelineData?.gaps || []}
-              events={timelineData?.events || []}
-              activity={timelineData?.activity || []}
-              frames={previewFrames}
-              camera={selectedCamera}
-              cursorTs={cursorTs}
-              onScrub={handleScrub}
-              onSeek={handleSeek}
-              onRangeChange={handleRangeChange}
-            />
+            {/* Footer: timestamp + coverage stats */}
+            <div style={styles.viewerFooter}>
+              <span style={styles.timestamp}>
+                {cursorTs ? formatDateTime(cursorTs) : '—'}
+              </span>
+              {timelineData && (
+                <span style={styles.coverageStats}>
+                  {timelineData.segments.length} segs ·{' '}
+                  {timelineData.coverage_pct.toFixed(1)}% cov ·{' '}
+                  {timelineData.events.length} evt
+                </span>
+              )}
+            </div>
           </div>
 
-          {timelineData && (
-            <div style={styles.coverage}>
-              {timelineData.segments.length} segments ·{' '}
-              {timelineData.gaps.length} gaps ·{' '}
-              {timelineData.coverage_pct.toFixed(1)}% coverage ·{' '}
-              {timelineData.events.length} events
+          {/* Right: vertical timeline column */}
+          <div style={styles.timelineCol}>
+            {/* Top range label */}
+            <div style={styles.rangeLabel}>
+              {new Date(rangeStart * 1000).toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
             </div>
-          )}
-        </>
-      )}
 
-      {multiMode && selectedCameras.length < 2 && (
+            {/* VerticalTimeline */}
+            <div style={{ flex: 1, minHeight: 0 }}>
+              <VerticalTimeline
+                startTs={rangeStart}
+                endTs={rangeEnd}
+                segments={timelineData?.segments || []}
+                gaps={timelineData?.gaps || []}
+                events={timelineData?.events || []}
+                activity={timelineData?.activity || []}
+                cursorTs={cursorTs}
+                onScrub={handleScrub}
+                onScrubEnd={handleScrubEnd}
+                onSeek={handleSeek}
+                onRangeChange={handleRangeChange}
+              />
+            </div>
+
+            {/* Bottom range label */}
+            <div style={{ ...styles.rangeLabel, borderTop: '1px solid #1e2130', borderBottom: 'none' }}>
+              {new Date(rangeEnd * 1000).toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </div>
+          </div>
+        </div>
+      ) : (
+        /* ── Split mode: not enough cameras selected ── */
         <div style={styles.splitHint}>
           Select 2–4 cameras above to enable split view.
         </div>
@@ -326,55 +406,101 @@ export default function App() {
 }
 
 const styles = {
-  container: { maxWidth: 1200, margin: '0 auto', padding: '16px 24px' },
+  container: {
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    overflow: 'hidden',
+    padding: '10px 14px 0',
+    boxSizing: 'border-box',
+  },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
     alignItems: 'center',
-    marginBottom: 16,
+    marginBottom: 10,
     borderBottom: '1px solid #2a2d37',
-    paddingBottom: 12,
+    paddingBottom: 8,
+    flexShrink: 0,
   },
-  title: { fontSize: 20, fontWeight: 600, color: '#e0e0e0' },
+  title: { fontSize: 18, fontWeight: 600, color: '#e0e0e0', margin: 0 },
   healthBadge: { fontSize: 12, color: '#888', display: 'flex', alignItems: 'center' },
   error: {
     background: '#3a1515',
     border: '1px solid #5a2020',
     color: '#f88',
-    padding: '8px 12px',
+    padding: '6px 12px',
     borderRadius: 4,
-    marginBottom: 12,
+    marginBottom: 8,
     fontSize: 13,
+    flexShrink: 0,
   },
   controls: {
     display: 'flex',
     alignItems: 'center',
-    gap: 12,
-    marginBottom: 16,
+    gap: 10,
+    marginBottom: 8,
     flexWrap: 'wrap',
+    flexShrink: 0,
   },
   rangeButtons: { display: 'flex', gap: 4 },
   rangeBtn: {
     background: '#1a1d27',
     border: '1px solid #333',
     color: '#aaa',
-    padding: '4px 12px',
+    padding: '4px 10px',
     borderRadius: 4,
     cursor: 'pointer',
-    fontSize: 13,
+    fontSize: 12,
+  },
+  singleLayout: {
+    display: 'flex',
+    flex: 1,
+    minHeight: 0,
+    gap: 8,
+    paddingBottom: 10,
+  },
+  viewerCol: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+  },
+  viewerFooter: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    flexShrink: 0,
+    padding: '2px 0',
   },
   timestamp: {
     color: '#4CAF50',
-    fontSize: 13,
-    fontFamily: 'monospace',
-    marginLeft: 'auto',
-  },
-  coverage: {
-    textAlign: 'center',
-    color: '#666',
     fontSize: 12,
-    marginTop: 8,
-    paddingBottom: 24,
+    fontFamily: 'monospace',
+  },
+  coverageStats: {
+    color: '#444',
+    fontSize: 11,
+  },
+  timelineCol: {
+    width: 190,
+    flexShrink: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    background: '#0a0c12',
+    border: '1px solid #1a1d27',
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
+  rangeLabel: {
+    padding: '4px 0',
+    textAlign: 'center',
+    fontSize: 11,
+    color: '#555',
+    borderBottom: '1px solid #1e2130',
+    flexShrink: 0,
+    fontFamily: 'monospace',
   },
   loading: { color: '#888', textAlign: 'center', paddingTop: 100, fontSize: 16 },
   splitHint: {

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -1,0 +1,369 @@
+/**
+ * VerticalTimeline — Full-height vertical canvas timeline.
+ *
+ * Time flows top (startTs) → bottom (endTs).
+ *
+ * Horizontal zones (left to right):
+ *   [0 … 50px]      — time tick labels (right-aligned, monospace 10px)
+ *   [50px]           — 1px separator line
+ *   [51 … w-18px]    — bar zone: segment bars, gap hatching, activity heatmap
+ *   [w-18px … w]     — event color markers
+ *
+ * Drawing order (bottom layer → top):
+ *   1.  Background
+ *   2.  Vertical separator lines
+ *   3.  Activity heatmap
+ *   4.  Segment bars
+ *   5.  Gap hatching
+ *   6.  "Now" dashed line (current wall-clock time, if in range)
+ *   7.  Time tick labels + horizontal hairlines across bar zone
+ *   8.  Event markers (right strip)
+ *   9.  Hover line (yellow, mouse position)
+ *   10. Playback cursor (red, cursorTs) + timestamp badge
+ *   11. Footer "scroll to zoom"
+ */
+
+import { useRef, useEffect, useState, useCallback } from 'react';
+import { formatTimeShort, clampTs, nowTs } from '../utils/time.js';
+
+const LABEL_WIDTH = 50;
+const EVENT_WIDTH = 18;
+const MIN_RANGE_SEC = 15 * 60;        // 15 minutes
+const MAX_RANGE_SEC = 7 * 24 * 3600;  // 7 days
+const ZOOM_FACTOR = 0.25;             // 25% per scroll tick
+
+const EVENT_COLORS = {
+  person: '#4CAF50',
+  car: '#2196F3',
+  dog: '#FF9800',
+  cat: '#9C27B0',
+  default: '#607D8B',
+};
+
+export default function VerticalTimeline({
+  startTs,
+  endTs,
+  segments = [],
+  gaps = [],
+  events = [],
+  activity = [],
+  cursorTs,
+  onScrub,
+  onScrubEnd,
+  onSeek,
+  onRangeChange,
+}) {
+  const canvasRef = useRef(null);
+  const containerRef = useRef(null);
+  const isDragging = useRef(false);
+
+  const [dims, setDims] = useState({ w: 190, h: 600 });
+  const [hoverY, setHoverY] = useState(null);
+
+  const range = endTs - startTs;
+
+  const tsToY = useCallback(
+    (ts) => ((ts - startTs) / range) * dims.h,
+    [startTs, range, dims.h]
+  );
+
+  const yToTs = useCallback(
+    (y) => clampTs(startTs + (y / dims.h) * range, startTs, endTs),
+    [startTs, endTs, range, dims.h]
+  );
+
+  // ── ResizeObserver ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const obs = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setDims({ w: Math.max(width, 1), h: Math.max(height, 1) });
+      }
+    });
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  // ── Canvas render ───────────────────────────────────────────────────────────
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const { w, h } = dims;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    canvas.style.width = `${w}px`;
+    canvas.style.height = `${h}px`;
+
+    const ctx = canvas.getContext('2d');
+    ctx.scale(dpr, dpr);
+
+    const barStart = LABEL_WIDTH + 1;  // x where bar zone begins
+    const barEnd = w - EVENT_WIDTH;    // x where bar zone ends
+    const barW = barEnd - barStart;
+
+    // 1. Background
+    ctx.fillStyle = '#090b10';
+    ctx.fillRect(0, 0, LABEL_WIDTH, h);
+    ctx.fillStyle = '#0f1117';
+    ctx.fillRect(LABEL_WIDTH, 0, w - LABEL_WIDTH, h);
+
+    // 2. Separator lines
+    ctx.fillStyle = '#1e2130';
+    ctx.fillRect(LABEL_WIDTH, 0, 1, h);
+    ctx.fillStyle = '#1e2130';
+    ctx.fillRect(barEnd, 0, 1, h);
+
+    // 3. Activity heatmap — horizontal bands
+    if (activity.length > 0) {
+      const maxCount = Math.max(...activity.map((b) => b.count), 1);
+      for (let i = 0; i < activity.length; i++) {
+        const bucket = activity[i];
+        if (bucket.count === 0) continue;
+        const intensity = bucket.count / maxCount;
+        const nextBucket = activity[i + 1];
+        const bucketEnd = nextBucket ? nextBucket.bucket_ts : bucket.bucket_ts + 60;
+        const y1 = Math.max(0, tsToY(bucket.bucket_ts));
+        const y2 = Math.min(h, tsToY(bucketEnd));
+        if (y2 <= y1) continue;
+        ctx.fillStyle = `rgba(255,152,0,${0.07 + intensity * 0.30})`;
+        ctx.fillRect(barStart, y1, barW, y2 - y1);
+      }
+    }
+
+    // 4. Segment bars
+    for (const seg of segments) {
+      const y1 = Math.max(0, tsToY(seg.start_ts));
+      const y2 = Math.min(h, tsToY(seg.end_ts));
+      if (y2 <= y1) continue;
+      ctx.fillStyle = seg.has_previews ? '#1e5a8a' : '#163d5c';
+      ctx.fillRect(barStart, y1, barW, y2 - y1);
+    }
+
+    // 5. Gap hatching — fill + diagonal lines (clipped to each gap rect)
+    for (const gap of gaps) {
+      const y1 = Math.max(0, tsToY(gap.start_ts));
+      const y2 = Math.min(h, tsToY(gap.end_ts));
+      if (y2 - y1 < 2) continue;
+
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(barStart, y1, barW, y2 - y1);
+      ctx.clip();
+
+      ctx.fillStyle = 'rgba(35,12,12,0.75)';
+      ctx.fillRect(barStart, y1, barW, y2 - y1);
+
+      ctx.strokeStyle = 'rgba(200,50,50,0.15)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      // Diagonal lines at 45°, sweeping across the gap rect
+      const spacing = 7;
+      const extent = barW + (y2 - y1);
+      for (let d = 0; d <= extent; d += spacing) {
+        ctx.moveTo(barStart + d, y1);
+        ctx.lineTo(barStart, y1 + d);
+      }
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // 6. "Now" dashed line (green, if wall-clock is within range)
+    const currentWallTs = nowTs();
+    if (currentWallTs >= startTs && currentWallTs <= endTs) {
+      const ny = tsToY(currentWallTs);
+      ctx.save();
+      ctx.strokeStyle = 'rgba(76,200,80,0.45)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 4]);
+      ctx.beginPath();
+      ctx.moveTo(barStart, ny);
+      ctx.lineTo(barEnd, ny);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    // 7. Time tick labels + horizontal hairlines across bar zone
+    let tickSec;
+    if (range <= 3600) tickSec = 300;
+    else if (range <= 14400) tickSec = 900;
+    else if (range <= 43200) tickSec = 1800;
+    else tickSec = 3600;
+
+    const firstTick = Math.ceil(startTs / tickSec) * tickSec;
+    for (let t = firstTick; t <= endTs; t += tickSec) {
+      const y = tsToY(t);
+
+      // Hairline across bar zone
+      ctx.strokeStyle = '#1a1e2b';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(barStart, y);
+      ctx.lineTo(barEnd, y);
+      ctx.stroke();
+
+      // Label (right-aligned in label column)
+      ctx.fillStyle = '#4a4f65';
+      ctx.font = '10px monospace';
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(formatTimeShort(t), LABEL_WIDTH - 4, y);
+    }
+
+    // 8. Event markers in right strip
+    for (const evt of events) {
+      const y1 = Math.max(0, tsToY(evt.start_ts));
+      const y2 = Math.min(h, tsToY(evt.end_ts || evt.start_ts + 5));
+      if (y2 <= y1) continue;
+      ctx.fillStyle = EVENT_COLORS[evt.label] || EVENT_COLORS.default;
+      ctx.fillRect(barEnd + 1, y1, EVENT_WIDTH - 1, Math.max(y2 - y1, 2));
+    }
+
+    // 9. Hover line (yellow, only when mouse is over canvas)
+    if (hoverY !== null) {
+      ctx.strokeStyle = 'rgba(255,220,80,0.85)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(barStart, hoverY);
+      ctx.lineTo(barEnd, hoverY);
+      ctx.stroke();
+    }
+
+    // 10. Playback cursor (red) + floating timestamp badge
+    if (cursorTs != null) {
+      const cy = tsToY(cursorTs);
+
+      ctx.strokeStyle = '#ff4444';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(barStart, cy);
+      ctx.lineTo(barEnd, cy);
+      ctx.stroke();
+
+      // Timestamp badge
+      const label = formatTimeShort(cursorTs);
+      ctx.font = 'bold 10px monospace';
+      ctx.textAlign = 'left';
+      ctx.textBaseline = 'top';
+      const textW = ctx.measureText(label).width;
+      const badgePad = 3;
+      const badgeX = barStart + 4;
+      const badgeY = Math.max(cy - 16, 0);
+
+      ctx.fillStyle = 'rgba(20,10,10,0.85)';
+      ctx.strokeStyle = '#ff4444';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.rect(badgeX - badgePad, badgeY, textW + badgePad * 2, 14);
+      ctx.fill();
+      ctx.stroke();
+
+      ctx.fillStyle = '#ff8888';
+      ctx.fillText(label, badgeX, badgeY + 2);
+    }
+
+    // 11. Footer "scroll to zoom"
+    ctx.font = '9px monospace';
+    ctx.fillStyle = '#2a2d37';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('scroll to zoom', w / 2, h - 2);
+  }, [dims, startTs, endTs, range, segments, gaps, events, activity, cursorTs, hoverY, tsToY]);
+
+  // ── Scroll-to-zoom ──────────────────────────────────────────────────────────
+  const handleWheel = useCallback(
+    (e) => {
+      if (!onRangeChange) return;
+      e.preventDefault();
+
+      const rect = canvasRef.current?.getBoundingClientRect();
+      if (!rect) return;
+
+      const y = e.clientY - rect.top;
+      const fraction = Math.max(0, Math.min(1, y / dims.h));
+      const pivotTs = startTs + fraction * range;
+
+      const zoomIn = e.deltaY < 0;
+      const factor = zoomIn ? (1 - ZOOM_FACTOR) : (1 + ZOOM_FACTOR);
+      const newRange = Math.min(MAX_RANGE_SEC, Math.max(MIN_RANGE_SEC, range * factor));
+
+      const newStart = pivotTs - fraction * newRange;
+      const newEnd = pivotTs + (1 - fraction) * newRange;
+
+      onRangeChange(newStart, newEnd);
+    },
+    [startTs, range, dims.h, onRangeChange]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.addEventListener('wheel', handleWheel, { passive: false });
+    return () => canvas.removeEventListener('wheel', handleWheel);
+  }, [handleWheel]);
+
+  // ── Mouse handlers ──────────────────────────────────────────────────────────
+  const getTs = useCallback(
+    (e) => {
+      const rect = canvasRef.current?.getBoundingClientRect();
+      if (!rect) return null;
+      return yToTs(e.clientY - rect.top);
+    },
+    [yToTs]
+  );
+
+  const handleMouseDown = useCallback(
+    (e) => {
+      isDragging.current = true;
+      const ts = getTs(e);
+      if (ts != null && onScrub) onScrub(ts);
+    },
+    [getTs, onScrub]
+  );
+
+  const handleMouseMove = useCallback(
+    (e) => {
+      const rect = canvasRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      setHoverY(e.clientY - rect.top);
+      const ts = getTs(e);
+      if (ts != null && onScrub) onScrub(ts);
+    },
+    [getTs, onScrub]
+  );
+
+  const handleMouseUp = useCallback(
+    (e) => {
+      if (!isDragging.current) return;
+      isDragging.current = false;
+      const ts = getTs(e);
+      if (ts != null && onSeek) onSeek(ts);
+    },
+    [getTs, onSeek]
+  );
+
+  const handleMouseLeave = useCallback(() => {
+    isDragging.current = false;
+    setHoverY(null);
+    if (onScrubEnd) onScrubEnd();
+  }, [onScrubEnd]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: '100%', height: '100%', userSelect: 'none', position: 'relative' }}
+    >
+      <canvas
+        ref={canvasRef}
+        style={{ cursor: 'crosshair', display: 'block' }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -11,6 +11,11 @@
  *     Frigate HLS stitches segments automatically.
  *   - absoluteTs = requested_ts + (currentTime - hlsStartOffset)
  *     Maps HLS stream-relative time back to wall-clock timestamps.
+ *
+ * scrubPreviewUrl prop:
+ *   When non-null, renders a position:absolute overlay over the video showing
+ *   the preview JPEG. Uses sticky-last-frame: the overlay image only updates
+ *   when a new Image fires .onload, preventing black flashes during rapid scrub.
  */
 
 import { useRef, useEffect, useState, useCallback } from 'react';
@@ -26,17 +31,58 @@ const HLS_CONFIG = {
   startPosition: -1,
 };
 
-export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSegmentAdvance }) {
+export default function VideoPlayer({
+  playbackTarget,
+  camera,
+  onTimeUpdate,
+  onSegmentAdvance,
+  scrubPreviewUrl,
+}) {
   const videoRef = useRef(null);
   const preloadRef = useRef(null);
   const hlsRef = useRef(null);
   const hlsStartOffset = useRef(0);
   const isHlsActive = useRef(false);
+  const loadingImgRef = useRef(null);
 
   const [isPlaying, setIsPlaying] = useState(false);
   const [displayTime, setDisplayTime] = useState(null);
   const [error, setError] = useState(null);
-  const [hlsMode, setHlsMode] = useState(false); // for UI indicator only
+  const [hlsMode, setHlsMode] = useState(false);
+
+  // Sticky-last-frame: only update displayedPreviewUrl when the new image loads.
+  // This prevents black flashes between frames during rapid scrubbing.
+  const [displayedPreviewUrl, setDisplayedPreviewUrl] = useState(null);
+
+  useEffect(() => {
+    if (!scrubPreviewUrl) return;
+
+    // Cancel any in-flight load
+    if (loadingImgRef.current) {
+      loadingImgRef.current.onload = null;
+      loadingImgRef.current.onerror = null;
+      loadingImgRef.current = null;
+    }
+
+    const img = new Image();
+    loadingImgRef.current = img;
+
+    img.onload = () => {
+      setDisplayedPreviewUrl(scrubPreviewUrl);
+      loadingImgRef.current = null;
+    };
+    img.onerror = () => {
+      // Keep last good frame rather than going blank
+      loadingImgRef.current = null;
+    };
+
+    img.src = scrubPreviewUrl;
+
+    return () => {
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [scrubPreviewUrl]);
 
   /** Destroy existing hls.js instance if any. */
   function _destroyHls() {
@@ -88,7 +134,6 @@ export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSe
             setError('HLS playback error — trying fallback');
             _destroyHls();
             setHlsMode(false);
-            // Fall through to MP4 in the next render (hls_url cleared by error state)
           }
         });
 
@@ -167,11 +212,9 @@ export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSe
 
     let absoluteTs;
     if (isHlsActive.current) {
-      // HLS: map stream-relative time back to wall-clock
       absoluteTs = playbackTarget.requested_ts +
                    (video.currentTime - hlsStartOffset.current);
     } else {
-      // MP4: segment_start_ts + offset within segment
       absoluteTs = playbackTarget.segment_start_ts + video.currentTime;
     }
 
@@ -180,7 +223,6 @@ export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSe
   }, [playbackTarget, onTimeUpdate]);
 
   const handleEnded = useCallback(() => {
-    // When HLS is active, Frigate handles continuity — no manual advance needed
     if (isHlsActive.current) {
       setIsPlaying(false);
       return;
@@ -194,7 +236,6 @@ export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSe
     if (onSegmentAdvance) {
       onSegmentAdvance(playbackTarget.next_segment_id);
     } else {
-      // Fallback for backwards compat (no parent handler)
       const video = videoRef.current;
       const preload = preloadRef.current;
       if (video && preload && preload.src) {
@@ -214,36 +255,88 @@ export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSe
   }, []);
 
   const hasTarget = playbackTarget != null;
+  const showOverlay = scrubPreviewUrl != null;
+  const showPlaceholder = !hasTarget && !showOverlay;
 
   return (
-    <div style={{ background: '#000', borderRadius: 6, overflow: 'hidden' }}>
-      <video
-        ref={videoRef}
-        style={{
-          width: '100%',
-          display: 'block',
-          maxHeight: 480,
-          background: '#000',
-          minHeight: hasTarget ? 270 : 120,
-        }}
-        onTimeUpdate={handleTimeUpdate}
-        onError={handleError}
-        onEnded={handleEnded}
-        onPlay={() => setIsPlaying(true)}
-        onPause={() => setIsPlaying(false)}
-        playsInline
-        muted
-      />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        background: '#000',
+        borderRadius: 6,
+        overflow: 'hidden',
+      }}
+    >
+      {/* Viewer area: video + overlay + placeholder */}
+      <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+        <video
+          ref={videoRef}
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'block',
+            background: '#000',
+            objectFit: 'contain',
+          }}
+          onTimeUpdate={handleTimeUpdate}
+          onError={handleError}
+          onEnded={handleEnded}
+          onPlay={() => setIsPlaying(true)}
+          onPause={() => setIsPlaying(false)}
+          playsInline
+          muted
+        />
 
-      {/* Hidden preload element for next MP4 segment */}
-      <video
-        ref={preloadRef}
-        style={{ display: 'none' }}
-        preload="auto"
-        muted
-      />
+        {/* Hidden preload element for next MP4 segment */}
+        <video ref={preloadRef} style={{ display: 'none' }} preload="auto" muted />
 
-      {/* Controls */}
+        {/* Scrub preview overlay — shown while hovering the timeline */}
+        {showOverlay && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: '#000',
+            }}
+          >
+            {displayedPreviewUrl && (
+              <img
+                src={displayedPreviewUrl}
+                alt="Preview"
+                style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+              />
+            )}
+          </div>
+        )}
+
+        {/* Placeholder when no playback target and no preview overlay */}
+        {showPlaceholder && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 8,
+              pointerEvents: 'none',
+            }}
+          >
+            <span style={{ fontSize: 52, color: '#2a2d37' }}>▶</span>
+            <span style={{ color: '#3a3d47', fontSize: 12, fontFamily: 'monospace' }}>
+              Hover timeline to preview · click to play
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Controls bar */}
       <div
         style={{
           display: 'flex',
@@ -252,6 +345,7 @@ export default function VideoPlayer({ playbackTarget, camera, onTimeUpdate, onSe
           padding: '8px 12px',
           background: '#111',
           borderTop: '1px solid #333',
+          flexShrink: 0,
         }}
       >
         <button


### PR DESCRIPTION
## Summary

- **`VerticalTimeline.jsx` (new component):** Full-height vertical canvas timeline replaces the horizontal scrub strip. Time flows top→bottom. Canvas zones: 50px label column with right-aligned time ticks, 1px separator, bar zone (segments/gaps/activity heatmap), 18px right event-color strip. Scroll-to-zoom pivots on Y mouse position. All mouse events fire `onScrub` (hover and drag identically produce preview); `mouseup` fires `onSeek`; `mouseleave` fires `onScrubEnd`. Uses ResizeObserver and devicePixelRatio scaling.

- **`VideoPlayer.jsx` (new `scrubPreviewUrl` prop):** When non-null, renders a `position:absolute` overlay covering the video with the scrub preview image. Sticky-last-frame pattern (`displayedPreviewUrl` state only updates on `Image.onload`) prevents black flashes during rapid scrubbing. Root layout changed to `flex column / height:100%` — parent controls sizing entirely. Placeholder shown when no `playbackTarget` and no overlay active.

- **`App.jsx` (2-column layout + goto datetime):** `height:100vh` flex-column, `overflow:hidden`. Single-camera view is a flex row: left `viewerCol` (VideoPlayer + footer showing green timestamp and coverage stats) and right `timelineCol` (190px fixed width, VerticalTimeline fills `flex:1` with range labels above/below). Added `hoverTs` state separate from `cursorTs` — hover moves the cursor line without triggering video decode; `handleSeek` clears `hoverTs` and commits playback. Added `toDatetimeLocal()` helper and "Go to" `datetime-local` input in the controls bar (single-camera mode only), which centers the current range around the chosen timestamp and calls `handleSeek`.

## Unchanged

`SplitView.jsx`, `Timeline.jsx`, `CameraSelector.jsx`, `AdminPanel.jsx`, all backend files, `api.js`, and `time.js` are untouched. All 71 existing backend tests continue to pass (`pytest tests/ -q`).

## Architecture invariant preserved

Scrubbing = image lookup (hover fires `onScrub` → `hoverTs` → `/api/preview/{camera}/{ts}` URL passed as `scrubPreviewUrl`). Playback = video decode (only triggered by `onSeek` → `fetchPlaybackTarget`). Never mixed.

## Test plan

- [ ] `cd backend && source .venv/bin/activate && pytest tests/ -q` — all 71 pass
- [ ] `cd frontend && npm run build` — builds clean (only chunk-size advisory warning, not an error)
- [ ] Single-camera: hover timeline → preview overlay appears on video; move cursor → overlay updates without black flash; click → video plays from that position
- [ ] Scroll on timeline → zooms in/out, range labels update
- [ ] "Go to" input → enter a datetime, click Go → range recenters, playback seeks
- [ ] Split mode → unaffected, toggle back to single → vertical timeline restores

🤖 Generated with [Claude Code](https://claude.com/claude-code)