### PR TITLE
feat(frontend): scale fonts ~33%, fill preview image, thicker cursor lines

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -288,7 +288,7 @@ export default function App() {
         {/* "Go to" group — single-camera mode only */}
         {!multiMode && (
           <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <span style={{ color: '#666', fontSize: 12 }}>Go to:</span>
+            <span style={{ color: '#666', fontSize: 16 }}>Go to:</span>
             <input
               type="datetime-local"
               value={gotoValue}
@@ -300,7 +300,7 @@ export default function App() {
                 color: '#aaa',
                 padding: '3px 6px',
                 borderRadius: 4,
-                fontSize: 12,
+                fontSize: 16,
               }}
             />
             <button onClick={handleGoto} style={styles.rangeBtn}>
@@ -423,8 +423,8 @@ const styles = {
     paddingBottom: 8,
     flexShrink: 0,
   },
-  title: { fontSize: 20, fontWeight: 600, color: '#e0e0e0', margin: 0 },
-  healthBadge: { fontSize: 13, color: '#888', display: 'flex', alignItems: 'center' },
+  title: { fontSize: 27, fontWeight: 600, color: '#e0e0e0', margin: 0 },
+  healthBadge: { fontSize: 17, color: '#888', display: 'flex', alignItems: 'center' },
   error: {
     background: '#3a1515',
     border: '1px solid #5a2020',
@@ -432,7 +432,7 @@ const styles = {
     padding: '6px 12px',
     borderRadius: 4,
     marginBottom: 8,
-    fontSize: 14,
+    fontSize: 19,
     flexShrink: 0,
   },
   controls: {
@@ -451,7 +451,7 @@ const styles = {
     padding: '4px 10px',
     borderRadius: 4,
     cursor: 'pointer',
-    fontSize: 12,
+    fontSize: 16,
   },
   singleLayout: {
     display: 'flex',
@@ -476,15 +476,15 @@ const styles = {
   },
   timestamp: {
     color: '#4CAF50',
-    fontSize: 13,
+    fontSize: 17,
     fontFamily: 'monospace',
   },
   coverageStats: {
     color: '#444',
-    fontSize: 12,
+    fontSize: 16,
   },
   timelineCol: {
-    width: 215,
+    width: 230,
     flexShrink: 0,
     display: 'flex',
     flexDirection: 'column',
@@ -496,7 +496,7 @@ const styles = {
   rangeLabel: {
     padding: '4px 0',
     textAlign: 'center',
-    fontSize: 12,
+    fontSize: 16,
     color: '#555',
     borderBottom: '1px solid #1e2130',
     flexShrink: 0,

--- a/frontend/src/components/CameraSelector.jsx
+++ b/frontend/src/components/CameraSelector.jsx
@@ -22,7 +22,7 @@ export default function CameraSelector({
 }) {
   if (!cameras || cameras.length === 0) {
     return (
-      <div style={{ color: '#888', fontSize: 13, padding: '8px 0' }}>
+      <div style={{ color: '#888', fontSize: 17, padding: '8px 0' }}>
         No cameras indexed yet. Check backend health.
       </div>
     );
@@ -31,7 +31,7 @@ export default function CameraSelector({
   if (!multiMode) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <label style={{ color: '#aaa', fontSize: 13 }}>Camera:</label>
+        <label style={{ color: '#aaa', fontSize: 17 }}>Camera:</label>
         <select
           value={selected || ''}
           onChange={(e) => onSelect && onSelect(e.target.value)}
@@ -41,7 +41,7 @@ export default function CameraSelector({
             border: '1px solid #333',
             borderRadius: 4,
             padding: '6px 12px',
-            fontSize: 14,
+            fontSize: 19,
             cursor: 'pointer',
             minWidth: 180,
           }}
@@ -69,7 +69,7 @@ export default function CameraSelector({
 
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-      <label style={{ color: '#aaa', fontSize: 13 }}>Cameras:</label>
+      <label style={{ color: '#aaa', fontSize: 17 }}>Cameras:</label>
       <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
         {cameras.map((cam) => {
           const checked = selectedMany.includes(cam.name);
@@ -87,7 +87,7 @@ export default function CameraSelector({
                 padding: '4px 10px',
                 cursor: disabled ? 'not-allowed' : 'pointer',
                 opacity: disabled ? 0.45 : 1,
-                fontSize: 13,
+                fontSize: 17,
                 color: checked ? '#e0e0e0' : '#888',
                 userSelect: 'none',
               }}
@@ -105,7 +105,7 @@ export default function CameraSelector({
         })}
       </div>
       {selectedMany.length > 0 && (
-        <span style={{ color: '#555', fontSize: 11 }}>
+        <span style={{ color: '#555', fontSize: 15 }}>
           {selectedMany.length}/{maxSelect} selected
         </span>
       )}

--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -299,7 +299,7 @@ export default function Timeline({
     if (activeTs != null) {
       const cx = tsToX(activeTs);
       ctx.strokeStyle = CURSOR_COLOR;
-      ctx.lineWidth = 2;
+      ctx.lineWidth = 4;
       ctx.beginPath();
       ctx.moveTo(cx, 0);
       ctx.lineTo(cx, TIMELINE_HEIGHT);
@@ -444,7 +444,7 @@ export default function Timeline({
           <img
             src={displayedUrl}
             alt="Preview"
-            style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+            style={{ width: '100%', height: '100%', objectFit: 'contain' }}
           />
         ) : null}
         {showPreview && displayTs != null && (

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -260,7 +260,7 @@ export default function VerticalTimeline({
       ctx.stroke();
 
       ctx.fillStyle = '#4a4f65';
-      ctx.font = '11px monospace';
+      ctx.font = '15px monospace';
       ctx.textAlign = 'right';
       ctx.textBaseline = 'middle';
       ctx.fillText(formatTimeShort(t), LABEL_WIDTH - 4, y);
@@ -290,31 +290,31 @@ export default function VerticalTimeline({
       const cy = tsToY(cursorTs);
 
       ctx.strokeStyle = '#ff4444';
-      ctx.lineWidth = 2;
+      ctx.lineWidth = 4;
       ctx.beginPath();
       ctx.moveTo(barStart, cy);
       ctx.lineTo(barEnd, cy);
       ctx.stroke();
 
       const label = formatTimeShort(cursorTs);
-      ctx.font = 'bold 11px monospace';
+      ctx.font = 'bold 15px monospace';
       ctx.textAlign = 'left';
       ctx.textBaseline = 'top';
       const textW = ctx.measureText(label).width;
       const badgePad = 3;
       const badgeX = barStart + 4;
-      const badgeY = Math.max(cy - 16, 0);
+      const badgeY = Math.max(cy - 21, 0);
 
       ctx.fillStyle = 'rgba(20,10,10,0.85)';
       ctx.strokeStyle = '#ff4444';
-      ctx.lineWidth = 1;
+      ctx.lineWidth = 1.5;
       ctx.beginPath();
-      ctx.rect(badgeX - badgePad, badgeY, textW + badgePad * 2, 14);
+      ctx.rect(badgeX - badgePad, badgeY, textW + badgePad * 2, 19);
       ctx.fill();
       ctx.stroke();
 
       ctx.fillStyle = '#ff8888';
-      ctx.fillText(label, badgeX, badgeY + 2);
+      ctx.fillText(label, badgeX, badgeY + 3);
     }
   }, [dims, startTs, endTs, range, segments, gaps, events, activity, cursorTs, hoverY, tsToY]);
 

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -308,7 +308,7 @@ export default function VideoPlayer({
               <img
                 src={displayedPreviewUrl}
                 alt="Preview"
-                style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+                style={{ width: '100%', height: '100%', objectFit: 'contain' }}
               />
             )}
           </div>
@@ -329,7 +329,7 @@ export default function VideoPlayer({
             }}
           >
             <span style={{ fontSize: 52, color: '#2a2d37' }}>▶</span>
-            <span style={{ color: '#3a3d47', fontSize: 13, fontFamily: 'monospace' }}>
+            <span style={{ color: '#3a3d47', fontSize: 17, fontFamily: 'monospace' }}>
               Hover timeline to preview · click to play
             </span>
           </div>
@@ -358,18 +358,18 @@ export default function VideoPlayer({
             padding: '4px 16px',
             borderRadius: 4,
             cursor: hasTarget ? 'pointer' : 'default',
-            fontSize: 13,
+            fontSize: 17,
           }}
         >
           {isPlaying ? '⏸ Pause' : '▶ Play'}
         </button>
 
-        <span style={{ color: '#aaa', fontSize: 13, fontFamily: 'monospace' }}>
+        <span style={{ color: '#aaa', fontSize: 17, fontFamily: 'monospace' }}>
           {displayTime != null ? formatTime(displayTime) : '--:--:--'}
         </span>
 
         {hasTarget && (
-          <span style={{ color: '#555', fontSize: 12, marginLeft: 'auto' }}>
+          <span style={{ color: '#555', fontSize: 16, marginLeft: 'auto' }}>
             segment {playbackTarget.segment_id}
             {!hlsMode && playbackTarget.next_segment_id && ' → ' + playbackTarget.next_segment_id}
             {' · '}
@@ -380,7 +380,7 @@ export default function VideoPlayer({
         {hasTarget && (
           <span
             style={{
-              fontSize: 11,
+              fontSize: 15,
               padding: '2px 6px',
               borderRadius: 10,
               background: hlsMode ? 'rgba(76,175,80,0.15)' : 'rgba(100,100,100,0.15)',
@@ -394,13 +394,13 @@ export default function VideoPlayer({
         )}
 
         {error && (
-          <span style={{ color: '#f44', fontSize: 12, marginLeft: 'auto' }}>
+          <span style={{ color: '#f44', fontSize: 16, marginLeft: 'auto' }}>
             {error}
           </span>
         )}
 
         {!hasTarget && !error && (
-          <span style={{ color: '#555', fontSize: 12 }}>
+          <span style={{ color: '#555', fontSize: 16 }}>
             Click timeline to seek
           </span>
         )}


### PR DESCRIPTION
## Summary

- **Font scaling (~×4/3):** Every explicit font-size bumped by approximately one-third across `VerticalTimeline`, `App`, `VideoPlayer`, and `CameraSelector`. Key sizes: tick labels 11→15px, cursor badge 11→15px, play button 13→17px, display time 13→17px, camera select 14→19px, header title 20→27px. `timelineCol` width increased 215→230 to accommodate wider tick labels. Badge rect height/offsets updated proportionally.

- **Scrub preview fills player:** VideoPlayer overlay `<img>` changed from `maxWidth/maxHeight: 100%` to `width/height: 100%` — the 320px thumbnail now scales up to fill the player area while `objectFit: contain` preserves aspect ratio. Same fix applied to the Timeline.jsx preview thumbnail for consistency.

- **Thicker cursor lines:** Playback cursor `lineWidth` 2→4 in both `VerticalTimeline` (vertical) and `Timeline` (horizontal/SplitView). Badge border lineWidth 1→1.5 in `VerticalTimeline` to stay proportional.

## Unchanged

All backend files, `api.js`, `time.js`, `SplitView.jsx`, and `AdminPanel.jsx` are untouched. All 71 backend tests pass.

## Test plan

- [ ] `cd backend && source .venv/bin/activate && pytest tests/ -q` — 71 passed
- [ ] `cd frontend && npm run build` — clean build
- [ ] Single-camera view: all text visibly larger, timeline tick labels readable
- [ ] Hover timeline: scrub preview fills the full player area (no small image in corner)
- [ ] Playback cursor: 4px red line clearly visible in both vertical and horizontal timelines
- [ ] Split view: horizontal timeline cursor also thickened, preview thumbnail fills its container

🤖 Generated with [Claude Code](https://claude.com/claude-code)