### PR TITLE
feat: responsive mobile layout — timeline below video on narrow screens

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,17 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
+
+function useIsMobile(breakpoint = 768) {
+  const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint);
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+    const handler = (e) => setIsMobile(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, [breakpoint]);
+  return isMobile;
+}
 import CameraSelector from './components/CameraSelector.jsx';
 import Timeline from './components/Timeline.jsx';
 import VerticalTimeline from './components/VerticalTimeline.jsx';
@@ -38,6 +49,7 @@ function toDatetimeLocal(ts) {
 }
 
 export default function App() {
+  const isMobile = useIsMobile();
   const [cameras, setCameras] = useState([]);
   const [selectedCamera, setSelectedCamera] = useState(null);
   const [selectedCameras, setSelectedCameras] = useState([]);
@@ -280,6 +292,8 @@ export default function App() {
             ...styles.rangeBtn,
             borderColor: multiMode ? '#2196F3' : '#333',
             color: multiMode ? '#2196F3' : '#aaa',
+            padding: isMobile ? '8px 14px' : '4px 10px',
+            fontSize: isMobile ? '15px' : '16px',
           }}
         >
           {multiMode ? '◈ Single' : '◈ Split'}
@@ -303,7 +317,11 @@ export default function App() {
                 fontSize: 16,
               }}
             />
-            <button onClick={handleGoto} style={styles.rangeBtn}>
+            <button onClick={handleGoto} style={{
+              ...styles.rangeBtn,
+              padding: isMobile ? '8px 14px' : '4px 10px',
+              fontSize: isMobile ? '15px' : '16px',
+            }}>
               Go
             </button>
           </div>
@@ -311,7 +329,11 @@ export default function App() {
 
         <div style={styles.rangeButtons}>
           {[1, 4, 8, 24].map((h) => (
-            <button key={h} onClick={() => setRange(h)} style={styles.rangeBtn}>
+            <button key={h} onClick={() => setRange(h)} style={{
+              ...styles.rangeBtn,
+              padding: isMobile ? '8px 14px' : '4px 10px',
+              fontSize: isMobile ? '15px' : '16px',
+            }}>
               {h}h
             </button>
           ))}
@@ -329,9 +351,9 @@ export default function App() {
         />
       ) : !multiMode ? (
         /* ── Single-camera: 2-column layout ── */
-        <div style={styles.singleLayout}>
-          {/* Left: video viewer column */}
-          <div style={styles.viewerCol}>
+        <div style={{ ...styles.singleLayout, flexDirection: isMobile ? 'column' : 'row' }}>
+          {/* Left/top: video viewer column */}
+          <div style={{ ...styles.viewerCol, flex: isMobile ? 'none' : 1 }}>
             <div style={{ flex: 1, minHeight: 0 }}>
               <VideoPlayer
                 playbackTarget={playbackTarget}
@@ -357,8 +379,13 @@ export default function App() {
             </div>
           </div>
 
-          {/* Right: vertical timeline column */}
-          <div style={styles.timelineCol}>
+          {/* Right/bottom: vertical timeline column */}
+          <div style={{
+            ...styles.timelineCol,
+            width: isMobile ? '100%' : 230,
+            height: isMobile ? 280 : undefined,
+            flexShrink: 0,
+          }}>
             {/* Top range label */}
             <div style={styles.rangeLabel}>
               {new Date(rangeStart * 1000).toLocaleTimeString([], {
@@ -381,6 +408,7 @@ export default function App() {
                 onScrubEnd={handleScrubEnd}
                 onSeek={handleSeek}
                 onRangeChange={handleRangeChange}
+                isMobile={isMobile}
                 onPreviewRequest={(ts) => {
                   const halfWindow = 5 * 60;
                   requestPreviews(selectedCamera, ts - halfWindow, ts + halfWindow).catch(() => {});

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -115,6 +115,7 @@ export default function VerticalTimeline({
   onSeek,
   onRangeChange,
   onPreviewRequest = null,
+  isMobile = false,
 }) {
   const canvasRef = useRef(null);
   const containerRef = useRef(null);
@@ -454,11 +455,26 @@ export default function VerticalTimeline({
       <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
         <canvas
           ref={canvasRef}
-          style={{ cursor: 'crosshair', display: 'block' }}
+          style={{ cursor: 'crosshair', display: 'block', touchAction: 'manipulation' }}
           onMouseDown={handleMouseDown}
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUp}
           onMouseLeave={handleMouseLeave}
+          onTouchStart={(e) => {
+            e.preventDefault();
+            const touch = e.touches[0];
+            handleMouseDown({ clientX: touch.clientX, clientY: touch.clientY });
+          }}
+          onTouchMove={(e) => {
+            e.preventDefault();
+            const touch = e.touches[0];
+            handleMouseMove({ clientX: touch.clientX, clientY: touch.clientY });
+          }}
+          onTouchEnd={(e) => {
+            e.preventDefault();
+            const touch = e.changedTouches[0];
+            handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
+          }}
         />
       </div>
 
@@ -476,7 +492,12 @@ export default function VerticalTimeline({
       >
         {/* − = zoom out = larger range = higher index */}
         <button
-          style={btnStyle}
+          style={{
+            ...btnStyle,
+            width: isMobile ? 36 : 28,
+            height: isMobile ? 36 : 28,
+            fontSize: isMobile ? 20 : 16,
+          }}
           onClick={() => applyZoom(zoomIdx + 1)}
           disabled={zoomIdx >= ZOOM_STOPS.length - 1}
           title="Zoom out"
@@ -508,7 +529,12 @@ export default function VerticalTimeline({
 
         {/* + = zoom in = smaller range = lower index */}
         <button
-          style={btnStyle}
+          style={{
+            ...btnStyle,
+            width: isMobile ? 36 : 28,
+            height: isMobile ? 36 : 28,
+            fontSize: isMobile ? 20 : 16,
+          }}
           onClick={() => applyZoom(zoomIdx - 1)}
           disabled={zoomIdx <= 0}
           title="Zoom in"


### PR DESCRIPTION
## Summary

- On screens narrower than 768px (mobile browsers), the single-camera view now stacks the video player above the vertical timeline instead of side by side
- Timeline renders as a 280px tall full-width horizontal band on mobile, auto-adapting via the existing ResizeObserver
- Zoom strip buttons are larger on mobile (36×36px, 20px font vs 28×28px, 16px) for easier touch targets
- Range preset and navigation buttons (1h/4h/8h/24h, Go, Split) have increased padding on mobile (`8px 14px` vs `4px 10px`)
- Touch events wired to the timeline canvas (`onTouchStart`/`onTouchMove`/`onTouchEnd`) so scrubbing works on iOS without relying on mouse event synthesis
- Double-tap zoom prevented on the canvas via `touch-action: manipulation`
- Desktop layout unchanged at ≥768px — `flexDirection: row`, timeline `width: 230px`

## Test plan

- [ ] On desktop (≥768px): verify side-by-side layout is unchanged
- [ ] On mobile (e.g. iPhone 15 Pro Max, ~430px): verify timeline appears below video as a horizontal 280px band
- [ ] On mobile: verify scrubbing works by dragging finger along the timeline canvas
- [ ] On mobile: verify no double-tap zoom on the timeline canvas
- [ ] On mobile: verify zoom +/− buttons and range preset buttons are comfortably tappable
- [ ] Resize browser window through the 768px breakpoint and verify layout switches responsively

🤖 Generated with [Claude Code](https://claude.com/claude-code)