### PR TITLE
feat: mobile UX overhaul + dynamic label filtering, event tinting, prev/next navigation, and Frigate snapshots

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -32,6 +32,7 @@ class EventInfo(BaseModel):
     end_ts: float | None
     label: str
     score: float | None
+    has_snapshot: bool = False
 
 
 class ActivityBucket(BaseModel):

--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -12,7 +12,9 @@ All timestamp parameters are Unix timestamps (float).
 import math
 from collections import defaultdict
 
+import httpx
 from fastapi import APIRouter, Query, HTTPException
+from fastapi.responses import Response
 
 from app.config import settings
 from app.models.database import get_db
@@ -207,7 +209,7 @@ async def get_timeline(
 
         # Events overlapping the range
         evt_rows = await db.execute_fetchall(
-            """SELECT id, camera, start_ts, end_ts, label, score
+            """SELECT id, camera, start_ts, end_ts, label, score, has_snapshot
                FROM events
                WHERE camera = ?
                  AND (end_ts IS NULL OR end_ts >= ?)
@@ -219,7 +221,7 @@ async def get_timeline(
         events = [
             EventInfo(
                 id=r[0], camera=r[1], start_ts=r[2], end_ts=r[3],
-                label=r[4], score=r[5],
+                label=r[4], score=r[5], has_snapshot=bool(r[6]),
             )
             for r in evt_rows
         ]
@@ -340,6 +342,24 @@ async def get_playback_target(
             next_segment_id=next_id,
             hls_url=hls_url,
         )
+
+
+@router.get("/events/{event_id}/snapshot")
+async def get_event_snapshot(event_id: str):
+    """Proxy Frigate event snapshot to avoid CORS issues on the frontend."""
+    url = f"{settings.frigate_api_url}/api/events/{event_id}/snapshot.jpg"
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(url)
+            if r.status_code == 200:
+                return Response(
+                    content=r.content,
+                    media_type="image/jpeg",
+                    headers={"Cache-Control": "public, max-age=86400"},
+                )
+    except Exception:
+        pass
+    raise HTTPException(status_code=404, detail="Snapshot not available")
 
 
 @router.post("/index/scan", response_model=list[ScanResult])

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@
  *   - SplitView path unchanged
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 
 function useIsMobile(breakpoint = 768) {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint);
@@ -35,17 +35,72 @@ import {
   fetchPlaybackTarget,
   fetchHealth,
   requestPreviews,
+  eventSnapshotUrl,
 } from './utils/api.js';
-import { todayStartTs, nowTs, formatDateTime } from './utils/time.js';
+import { todayStartTs, nowTs, formatDateTime, formatTime } from './utils/time.js';
 
 const MIN_RANGE_SEC = 15 * 60;
 const MAX_RANGE_SEC = 7 * 24 * 3600;
+
+const LABEL_COLORS = {
+  person: '#4CAF50',
+  car: '#2196F3',
+  dog: '#FF9800',
+  cat: '#9C27B0',
+  default: '#607D8B',
+};
 
 /** Format a Unix timestamp for a datetime-local input value. */
 function toDatetimeLocal(ts) {
   const d = new Date(ts * 1000);
   const pad = (n) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function LabelFilterPills({ availableLabels, activeLabels, onToggle, onToggleAll, isMobile }) {
+  if (!availableLabels?.length) return null;
+  const allActive = activeLabels === null;
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 5, padding: '4px 0', alignItems: 'center' }}>
+      <span style={{ fontSize: 11, color: '#555', marginRight: 2, flexShrink: 0 }}>
+        Filter:
+      </span>
+      <button
+        onClick={onToggleAll}
+        style={{
+          padding: '3px 9px', borderRadius: 12,
+          border: `1px solid ${allActive ? '#aaa' : '#333'}`,
+          background: allActive ? '#2a2d37' : 'transparent',
+          color: allActive ? '#e0e0e0' : '#555',
+          fontSize: isMobile ? 13 : 11,
+          cursor: 'pointer', fontFamily: 'monospace', flexShrink: 0,
+        }}
+      >all</button>
+      {availableLabels.map(label => {
+        const color = LABEL_COLORS[label] ?? LABEL_COLORS.default;
+        const isActive = activeLabels === null || activeLabels.has(label);
+        return (
+          <button key={label} onClick={() => onToggle(label)} style={{
+            padding: '3px 9px', borderRadius: 12,
+            border: `1px solid ${isActive ? color : '#333'}`,
+            background: isActive ? `${color}22` : 'transparent',
+            color: isActive ? color : '#555',
+            fontSize: isMobile ? 13 : 11,
+            cursor: 'pointer', fontFamily: 'monospace',
+            display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0,
+          }}>
+            <span style={{
+              width: 6, height: 6, borderRadius: '50%',
+              background: isActive ? color : '#555',
+              display: 'inline-block', flexShrink: 0,
+            }}/>
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 export default function App() {
@@ -68,6 +123,25 @@ export default function App() {
   const [rangeEnd, setRangeEnd] = useState(nowTs());
 
   const [gotoValue, setGotoValue] = useState(() => toDatetimeLocal(nowTs()));
+
+  // Mobile header expand/collapse
+  const [healthExpanded, setHealthExpanded] = useState(false);
+  useEffect(() => {
+    if (!healthExpanded) return;
+    const t = setTimeout(() => setHealthExpanded(false), 4000);
+    return () => clearTimeout(t);
+  }, [healthExpanded]);
+
+  // Label filter state — persisted to localStorage, null means "all"
+  const [activeLabels, setActiveLabels] = useState(() => {
+    try {
+      const stored = localStorage.getItem('frigate-active-labels');
+      return stored ? new Set(JSON.parse(stored)) : null;
+    } catch { return null; }
+  });
+
+  // Event snapshot state (from prev/next navigation)
+  const [activeEventSnapshot, setActiveEventSnapshot] = useState(null);
 
   // ─── Init: load cameras + health ───
   useEffect(() => {
@@ -123,6 +197,18 @@ export default function App() {
     return () => { cancelled = true; };
   }, [selectedCamera, rangeStart, rangeEnd, multiMode]);
 
+  // ─── Derived label lists ───
+  const availableLabels = useMemo(() => {
+    if (!timelineData?.events?.length) return [];
+    return [...new Set(timelineData.events.map(e => e.label))].sort();
+  }, [timelineData]);
+
+  const filteredEvents = useMemo(() => {
+    if (!timelineData?.events) return [];
+    if (activeLabels === null) return timelineData.events;
+    return timelineData.events.filter(e => activeLabels.has(e.label));
+  }, [timelineData, activeLabels]);
+
   // ─── Range change (from zoom or presets) ───
   const handleRangeChange = useCallback((newStart, newEnd) => {
     const newRange = newEnd - newStart;
@@ -142,12 +228,13 @@ export default function App() {
     setHoverTs(null);
   }, []);
 
-  // ─── Seek handler: commits playback, clears hover ───
+  // ─── Seek handler: commits playback, clears hover + snapshot ───
   const handleSeek = useCallback(
     async (ts) => {
       if (!selectedCamera) return;
       setHoverTs(null);
       setCursorTs(ts);
+      setActiveEventSnapshot(null);
 
       try {
         const target = await fetchPlaybackTarget(selectedCamera, ts);
@@ -186,6 +273,7 @@ export default function App() {
     setPlaybackTarget(null);
     setTimelineData(null);
     setPreviewFrames([]);
+    setActiveEventSnapshot(null);
   }, []);
 
   // ─── Multi-camera selection ───
@@ -222,6 +310,64 @@ export default function App() {
     handleSeek(ts);
   }, [gotoValue, rangeStart, rangeEnd, handleRangeChange, handleSeek]);
 
+  // ─── Label filter handlers ───
+  const toggleLabel = useCallback((label) => {
+    setActiveLabels(prev => {
+      const current = prev ?? new Set(availableLabels);
+      const next = new Set(current);
+      if (next.has(label)) { next.delete(label); } else { next.add(label); }
+      try {
+        localStorage.setItem('frigate-active-labels', JSON.stringify([...next]));
+      } catch {}
+      return next;
+    });
+  }, [availableLabels]);
+
+  const toggleAllLabels = useCallback(() => {
+    setActiveLabels(null);
+    try { localStorage.removeItem('frigate-active-labels'); } catch {}
+  }, []);
+
+  // ─── Event navigation ───
+  const navigateEvent = useCallback(async (direction) => {
+    if (!filteredEvents.length) return;
+    const sorted = [...filteredEvents].sort((a, b) => a.start_ts - b.start_ts);
+    const current = cursorTs ?? 0;
+
+    let target;
+    if (direction === 'next') {
+      target = sorted.find(e => e.start_ts > current + 1) ?? sorted[0];
+    } else {
+      target = [...sorted].reverse().find(e => e.start_ts < current - 1)
+               ?? sorted[sorted.length - 1];
+    }
+
+    if (!target) return;
+
+    setCursorTs(target.start_ts);
+    try {
+      const playTarget = await fetchPlaybackTarget(selectedCamera, target.start_ts);
+      setPlaybackTarget(playTarget);
+    } catch {}
+
+    if (target.has_snapshot) {
+      setActiveEventSnapshot({
+        url: eventSnapshotUrl(target.id),
+        label: target.label,
+        score: target.score,
+        ts: target.start_ts,
+      });
+    } else {
+      setActiveEventSnapshot(null);
+    }
+
+    // Re-center range if event is outside current view
+    if (target.start_ts < rangeStart || target.start_ts > rangeEnd) {
+      const halfRange = (rangeEnd - rangeStart) / 2;
+      handleRangeChange(target.start_ts - halfRange, target.start_ts + halfRange);
+    }
+  }, [filteredEvents, cursorTs, selectedCamera, rangeStart, rangeEnd, handleRangeChange]);
+
   // ─── Derive scrub preview URL ───
   const activePreviewUrl =
     hoverTs != null && selectedCamera
@@ -240,105 +386,216 @@ export default function App() {
   return (
     <div style={styles.container}>
       {/* Header */}
-      <div style={styles.header}>
-        <h1 style={styles.title}>Frigate Review Accelerator</h1>
-        {health && (
-          <div style={styles.healthBadge}>
-            <span
-              style={{
+      {isMobile ? (
+        <div style={{ marginBottom: 8, borderBottom: '1px solid #2a2d37', paddingBottom: 6, flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', height: 40 }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{
+                width: 8, height: 8, borderRadius: '50%',
+                background: health?.frigate_reachable ? '#4CAF50' : '#f44',
                 display: 'inline-block',
-                width: 8,
-                height: 8,
-                borderRadius: '50%',
-                background: health.frigate_reachable ? '#4CAF50' : '#f44',
-                marginRight: 6,
-              }}
-            />
-            {health.total_segments.toLocaleString()} segs
-            {' · '}
-            {health.total_previews.toLocaleString()} previews
-            {health.pending_previews > 0 && (
-              <span style={{ color: '#888' }}>
-                {' · '}{health.pending_previews.toLocaleString()} pending
-              </span>
-            )}
+              }} />
+              <span style={{ fontSize: 17, fontWeight: 600, color: '#e0e0e0' }}>Frigate</span>
+            </div>
+            <button
+              onClick={() => setHealthExpanded(v => !v)}
+              style={{ background: 'none', border: 'none', color: '#666', fontSize: 18, cursor: 'pointer', padding: '0 4px' }}
+            >⋯</button>
           </div>
-        )}
-      </div>
+          {healthExpanded && health && (
+            <div style={{ fontSize: 13, color: '#888', paddingBottom: 4 }}>
+              {health.total_segments.toLocaleString()} segs ·{' '}
+              {health.total_previews.toLocaleString()} previews ·{' '}
+              {health.pending_previews.toLocaleString()} pending
+            </div>
+          )}
+        </div>
+      ) : (
+        <div style={styles.header}>
+          <h1 style={styles.title}>Frigate Review Accelerator</h1>
+          {health && (
+            <div style={styles.healthBadge}>
+              <span
+                style={{
+                  display: 'inline-block',
+                  width: 8,
+                  height: 8,
+                  borderRadius: '50%',
+                  background: health.frigate_reachable ? '#4CAF50' : '#f44',
+                  marginRight: 6,
+                }}
+              />
+              {health.total_segments.toLocaleString()} segs
+              {' · '}
+              {health.total_previews.toLocaleString()} previews
+              {health.pending_previews > 0 && (
+                <span style={{ color: '#888' }}>
+                  {' · '}{health.pending_previews.toLocaleString()} pending
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
 
       {error && <div style={styles.error}>{error}</div>}
 
       {/* Controls */}
-      <div style={styles.controls}>
-        {!multiMode ? (
-          <CameraSelector
-            cameras={cameras}
-            selected={selectedCamera}
-            onSelect={handleCameraChange}
-          />
-        ) : (
-          <CameraSelector
-            cameras={cameras}
-            selectedMany={selectedCameras}
-            onSelectMany={handleSelectMany}
-            multiMode={true}
-            maxSelect={4}
-          />
-        )}
-
-        <button
-          onClick={handleToggleMultiMode}
-          style={{
-            ...styles.rangeBtn,
-            borderColor: multiMode ? '#2196F3' : '#333',
-            color: multiMode ? '#2196F3' : '#aaa',
-            padding: isMobile ? '8px 14px' : '4px 10px',
-            fontSize: isMobile ? '15px' : '16px',
-          }}
-        >
-          {multiMode ? '◈ Single' : '◈ Split'}
-        </button>
-
-        {/* "Go to" group — single-camera mode only */}
-        {!multiMode && (
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <span style={{ color: '#666', fontSize: 16 }}>Go to:</span>
-            <input
-              type="datetime-local"
-              value={gotoValue}
-              onChange={(e) => setGotoValue(e.target.value)}
+      {isMobile ? (
+        <div style={{ flexShrink: 0, marginBottom: 8 }}>
+          {/* Row 1: Camera + Split */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+            {!multiMode ? (
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <CameraSelector
+                  cameras={cameras}
+                  selected={selectedCamera}
+                  onSelect={handleCameraChange}
+                  isMobile={true}
+                />
+              </div>
+            ) : (
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <CameraSelector
+                  cameras={cameras}
+                  selectedMany={selectedCameras}
+                  onSelectMany={handleSelectMany}
+                  multiMode={true}
+                  maxSelect={4}
+                  isMobile={true}
+                />
+              </div>
+            )}
+            <button
+              onClick={handleToggleMultiMode}
               style={{
-                colorScheme: 'dark',
-                background: '#1a1d27',
-                border: '1px solid #333',
-                color: '#aaa',
-                padding: '3px 6px',
-                borderRadius: 4,
-                fontSize: 16,
+                ...styles.rangeBtn,
+                borderColor: multiMode ? '#2196F3' : '#333',
+                color: multiMode ? '#2196F3' : '#aaa',
+                padding: '10px 16px',
+                fontSize: '15px',
+                minHeight: 44,
+                flexShrink: 0,
               }}
-            />
-            <button onClick={handleGoto} style={{
-              ...styles.rangeBtn,
-              padding: isMobile ? '8px 14px' : '4px 10px',
-              fontSize: isMobile ? '15px' : '16px',
-            }}>
-              Go
+            >
+              {multiMode ? '◈ Single' : '◈ Split'}
             </button>
           </div>
-        )}
-
-        <div style={styles.rangeButtons}>
-          {[1, 4, 8, 24].map((h) => (
-            <button key={h} onClick={() => setRange(h)} style={{
-              ...styles.rangeBtn,
-              padding: isMobile ? '8px 14px' : '4px 10px',
-              fontSize: isMobile ? '15px' : '16px',
-            }}>
-              {h}h
-            </button>
-          ))}
+          {/* Row 2: Range presets + Go group */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'nowrap', overflowX: 'auto' }}>
+            {[1, 4, 8, 24].map((h) => (
+              <button key={h} onClick={() => setRange(h)} style={{
+                ...styles.rangeBtn,
+                padding: '10px 16px',
+                fontSize: '15px',
+                minHeight: 44,
+                flexShrink: 0,
+              }}>
+                {h}h
+              </button>
+            ))}
+            {!multiMode && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+                <input
+                  type="datetime-local"
+                  value={gotoValue}
+                  onChange={(e) => setGotoValue(e.target.value)}
+                  style={{
+                    colorScheme: 'dark',
+                    background: '#1a1d27',
+                    border: '1px solid #333',
+                    color: '#aaa',
+                    padding: '3px 6px',
+                    borderRadius: 4,
+                    fontSize: 16,
+                  }}
+                />
+                <button onClick={handleGoto} style={{
+                  ...styles.rangeBtn,
+                  padding: '10px 16px',
+                  fontSize: '15px',
+                  minHeight: 44,
+                  flexShrink: 0,
+                }}>
+                  Go
+                </button>
+              </div>
+            )}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div style={styles.controls}>
+          {!multiMode ? (
+            <CameraSelector
+              cameras={cameras}
+              selected={selectedCamera}
+              onSelect={handleCameraChange}
+            />
+          ) : (
+            <CameraSelector
+              cameras={cameras}
+              selectedMany={selectedCameras}
+              onSelectMany={handleSelectMany}
+              multiMode={true}
+              maxSelect={4}
+            />
+          )}
+
+          <button
+            onClick={handleToggleMultiMode}
+            style={{
+              ...styles.rangeBtn,
+              borderColor: multiMode ? '#2196F3' : '#333',
+              color: multiMode ? '#2196F3' : '#aaa',
+            }}
+          >
+            {multiMode ? '◈ Single' : '◈ Split'}
+          </button>
+
+          {/* "Go to" group — single-camera mode only */}
+          {!multiMode && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={{ color: '#666', fontSize: 16 }}>Go to:</span>
+              <input
+                type="datetime-local"
+                value={gotoValue}
+                onChange={(e) => setGotoValue(e.target.value)}
+                style={{
+                  colorScheme: 'dark',
+                  background: '#1a1d27',
+                  border: '1px solid #333',
+                  color: '#aaa',
+                  padding: '3px 6px',
+                  borderRadius: 4,
+                  fontSize: 16,
+                }}
+              />
+              <button onClick={handleGoto} style={styles.rangeBtn}>
+                Go
+              </button>
+            </div>
+          )}
+
+          <div style={styles.rangeButtons}>
+            {[1, 4, 8, 24].map((h) => (
+              <button key={h} onClick={() => setRange(h)} style={styles.rangeBtn}>
+                {h}h
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Label filter pills (single-camera mode only) */}
+      {!multiMode && (
+        <LabelFilterPills
+          availableLabels={availableLabels}
+          activeLabels={activeLabels}
+          onToggle={toggleLabel}
+          onToggleAll={toggleAllLabels}
+          isMobile={isMobile}
+        />
+      )}
 
       {/* Main content */}
       {multiMode && selectedCameras.length >= 2 ? (
@@ -351,7 +608,11 @@ export default function App() {
         />
       ) : !multiMode ? (
         /* ── Single-camera: 2-column layout ── */
-        <div style={{ ...styles.singleLayout, flexDirection: isMobile ? 'column' : 'row' }}>
+        <div style={{
+          ...styles.singleLayout,
+          flexDirection: isMobile ? 'column' : 'row',
+          overflow: 'hidden',
+        }}>
           {/* Left/top: video viewer column */}
           <div style={{ ...styles.viewerCol, flex: isMobile ? 'none' : 1 }}>
             <div style={{ flex: 1, minHeight: 0 }}>
@@ -361,19 +622,22 @@ export default function App() {
                 onTimeUpdate={handlePlaybackTimeUpdate}
                 onSegmentAdvance={handleSegmentAdvance}
                 scrubPreviewUrl={activePreviewUrl}
+                isMobile={isMobile}
+                eventSnapshot={activeEventSnapshot}
+                onSeek={handleSeek}
               />
             </div>
 
             {/* Footer: timestamp + coverage stats */}
             <div style={styles.viewerFooter}>
               <span style={styles.timestamp}>
-                {cursorTs ? formatDateTime(cursorTs) : '—'}
+                {cursorTs ? (isMobile ? formatTime(cursorTs) : formatDateTime(cursorTs)) : '—'}
               </span>
               {timelineData && (
                 <span style={styles.coverageStats}>
                   {timelineData.segments.length} segs ·{' '}
                   {timelineData.coverage_pct.toFixed(1)}% cov ·{' '}
-                  {timelineData.events.length} evt
+                  {filteredEvents.length} evt
                 </span>
               )}
             </div>
@@ -383,8 +647,9 @@ export default function App() {
           <div style={{
             ...styles.timelineCol,
             width: isMobile ? '100%' : 230,
-            height: isMobile ? 280 : undefined,
-            flexShrink: 0,
+            flex: isMobile ? 1 : undefined,
+            minHeight: isMobile ? 320 : undefined,
+            flexShrink: isMobile ? undefined : 0,
           }}>
             {/* Top range label */}
             <div style={styles.rangeLabel}>
@@ -401,7 +666,7 @@ export default function App() {
                 endTs={rangeEnd}
                 segments={timelineData?.segments || []}
                 gaps={timelineData?.gaps || []}
-                events={timelineData?.events || []}
+                events={filteredEvents}
                 activity={timelineData?.activity || []}
                 cursorTs={cursorTs}
                 onScrub={handleScrub}
@@ -415,6 +680,27 @@ export default function App() {
                 }}
               />
             </div>
+
+            {/* Prev/Next event navigation */}
+            {filteredEvents.length > 0 && (
+              <div style={{
+                display: 'flex', alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '4px 8px',
+                borderTop: '1px solid #1e2130',
+                flexShrink: 0,
+              }}>
+                <button onClick={() => navigateEvent('prev')} style={styles.navBtn}>
+                  ‹ prev
+                </button>
+                <span style={{ fontSize: 10, color: '#444', fontFamily: 'monospace' }}>
+                  {filteredEvents.length} evt
+                </span>
+                <button onClick={() => navigateEvent('next')} style={styles.navBtn}>
+                  next ›
+                </button>
+              </div>
+            )}
 
             {/* Bottom range label */}
             <div style={{ ...styles.rangeLabel, borderTop: '1px solid #1e2130', borderBottom: 'none' }}>
@@ -491,6 +777,7 @@ const styles = {
     minHeight: 0,
     gap: 8,
     paddingBottom: 10,
+    overflow: 'hidden',
   },
   viewerCol: {
     flex: 1,
@@ -532,6 +819,16 @@ const styles = {
     color: '#555',
     borderBottom: '1px solid #1e2130',
     flexShrink: 0,
+    fontFamily: 'monospace',
+  },
+  navBtn: {
+    background: '#1a1d27',
+    border: '1px solid #333',
+    color: '#aaa',
+    padding: '4px 10px',
+    borderRadius: 4,
+    cursor: 'pointer',
+    fontSize: 12,
     fontFamily: 'monospace',
   },
   loading: { color: '#888', textAlign: 'center', paddingTop: 100, fontSize: 16 },

--- a/frontend/src/components/CameraSelector.jsx
+++ b/frontend/src/components/CameraSelector.jsx
@@ -19,6 +19,7 @@ export default function CameraSelector({
   onSelectMany,
   multiMode = false,
   maxSelect = 4,
+  isMobile = false,
 }) {
   if (!cameras || cameras.length === 0) {
     return (
@@ -31,7 +32,7 @@ export default function CameraSelector({
   if (!multiMode) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <label style={{ color: '#aaa', fontSize: 17 }}>Camera:</label>
+        {!isMobile && <label style={{ color: '#aaa', fontSize: 17 }}>Camera:</label>}
         <select
           value={selected || ''}
           onChange={(e) => onSelect && onSelect(e.target.value)}
@@ -41,14 +42,17 @@ export default function CameraSelector({
             border: '1px solid #333',
             borderRadius: 4,
             padding: '6px 12px',
-            fontSize: 19,
+            fontSize: isMobile ? 16 : 19,
             cursor: 'pointer',
-            minWidth: 180,
+            minWidth: isMobile ? undefined : 180,
+            width: isMobile ? '100%' : undefined,
           }}
         >
           {cameras.map((cam) => (
             <option key={cam.name} value={cam.name}>
-              {cam.name} ({cam.segment_count} segs · {cam.preview_count} frames)
+              {isMobile
+                ? cam.name
+                : `${cam.name} (${cam.segment_count} segs · ${cam.preview_count} frames)`}
             </option>
           ))}
         </select>

--- a/frontend/src/components/SplitView.jsx
+++ b/frontend/src/components/SplitView.jsx
@@ -8,6 +8,9 @@
  *
  * When syncCursors is on, seeking on any camera seeks all cameras to the
  * same timestamp.
+ *
+ * TODO: propagate global activeLabels filter and event navigation to split
+ * view camera panes (deferred — single-camera mode only for now)
  */
 
 import { useState, useEffect, useCallback } from 'react';

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -64,6 +64,7 @@ const ZOOM_STOP_LABELS = [
 ];
 
 const PAN_FRACTION = 0.15; // 15% of range per scroll tick
+const MIN_RANGE_SEC = 15 * 60;
 
 const EVENT_COLORS = {
   person: '#4CAF50',
@@ -120,6 +121,7 @@ export default function VerticalTimeline({
   const canvasRef = useRef(null);
   const containerRef = useRef(null);
   const isDragging = useRef(false);
+  const touchStartRef = useRef(null);
 
   const [dims, setDims] = useState({ w: 215, h: 600 });
   const [hoverY, setHoverY] = useState(null);
@@ -146,7 +148,7 @@ export default function VerticalTimeline({
 
   // ── ResizeObserver ──────────────────────────────────────────────────────────
   useEffect(() => {
-    const el = containerRef.current;
+    const el = canvasRef.current;
     if (!el) return;
     const obs = new ResizeObserver((entries) => {
       for (const entry of entries) {
@@ -167,8 +169,6 @@ export default function VerticalTimeline({
     const dpr = window.devicePixelRatio || 1;
     canvas.width = w * dpr;
     canvas.height = h * dpr;
-    canvas.style.width = `${w}px`;
-    canvas.style.height = `${h}px`;
 
     const ctx = canvas.getContext('2d');
     ctx.scale(dpr, dpr);
@@ -214,6 +214,35 @@ export default function VerticalTimeline({
       ctx.fillRect(barStart, y1, barW, y2 - y1);
     }
 
+    // 4b. Event density tinting — blend segment bars toward amber based on activity
+    if (events.length > 0) {
+      for (const seg of segments) {
+        const segDur = seg.end_ts - seg.start_ts;
+        if (segDur <= 0) continue;
+
+        let coveredSec = 0;
+        for (const evt of events) {
+          const evtEnd = evt.end_ts ?? evt.start_ts + 5;
+          const overlapStart = Math.max(seg.start_ts, evt.start_ts);
+          const overlapEnd = Math.min(seg.end_ts, evtEnd);
+          if (overlapEnd > overlapStart) coveredSec += overlapEnd - overlapStart;
+        }
+
+        const density = Math.min(1, coveredSec / Math.min(segDur, 300));
+        if (density < 0.01) continue;
+
+        const y1 = Math.max(0, tsToY(seg.start_ts));
+        const y2 = Math.min(h, tsToY(seg.end_ts));
+        if (y2 <= y1) continue;
+
+        const r = Math.round(30 + density * 154);
+        const g = Math.round(100 + density * 24);
+        const b = Math.round(160 - density * 118);
+        ctx.fillStyle = `rgba(${r},${g},${b},${0.3 + density * 0.5})`;
+        ctx.fillRect(barStart, y1, barW, y2 - y1);
+      }
+    }
+
     // 5. Gap hatching — fill + diagonal lines (clipped to each gap rect)
     for (const gap of gaps) {
       const y1 = Math.max(0, tsToY(gap.start_ts));
@@ -257,11 +286,24 @@ export default function VerticalTimeline({
     }
 
     // 7. Time tick labels + horizontal hairlines across bar zone
-    let tickSec;
-    if (range <= 3600) tickSec = 300;
-    else if (range <= 14400) tickSec = 900;
-    else if (range <= 43200) tickSec = 1800;
-    else tickSec = 3600;
+    const TICK_INTERVALS = [300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400];
+    const MIN_TICK_SPACING_PX = 28;
+    const maxTicks = Math.floor(h / MIN_TICK_SPACING_PX);
+    const minIntervalSec = range / maxTicks;
+    const tickSec = TICK_INTERVALS.find((t) => t >= minIntervalSec) ?? 86400;
+
+    // Build per-tick-bucket event map for dots
+    const LABEL_COLORS_MAP = {
+      person: '#4CAF50', car: '#2196F3', dog: '#FF9800',
+      cat: '#9C27B0', default: '#607D8B',
+    };
+    const tickBucketEvents = {};
+    for (const evt of events) {
+      const bucketTs = Math.floor(evt.start_ts / tickSec) * tickSec;
+      if (!tickBucketEvents[bucketTs]) tickBucketEvents[bucketTs] = {};
+      tickBucketEvents[bucketTs][evt.label] =
+        (tickBucketEvents[bucketTs][evt.label] || 0) + 1;
+    }
 
     const firstTick = Math.ceil(startTs / tickSec) * tickSec;
     for (let t = firstTick; t <= endTs; t += tickSec) {
@@ -279,6 +321,20 @@ export default function VerticalTimeline({
       ctx.textAlign = 'right';
       ctx.textBaseline = 'middle';
       ctx.fillText(formatTimeShort(t), LABEL_WIDTH - 4, y);
+
+      // Colored dot when events occurred in this tick bucket
+      const bucketEvts = tickBucketEvents[t];
+      if (bucketEvts) {
+        const topLabel = Object.entries(bucketEvts)
+          .sort((a, b) => b[1] - a[1])[0][0];
+        const dotColor = LABEL_COLORS_MAP[topLabel] ?? LABEL_COLORS_MAP.default;
+        ctx.beginPath();
+        ctx.arc(LABEL_WIDTH - 18, y, 3, 0, Math.PI * 2);
+        ctx.fillStyle = dotColor;
+        ctx.globalAlpha = 0.85;
+        ctx.fill();
+        ctx.globalAlpha = 1;
+      }
     }
 
     // 8. Event markers in right strip
@@ -451,32 +507,48 @@ export default function VerticalTimeline({
         flexDirection: 'column',
       }}
     >
-      {/* Canvas fills all remaining vertical space */}
-      <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
-        <canvas
-          ref={canvasRef}
-          style={{ cursor: 'crosshair', display: 'block', touchAction: 'manipulation' }}
-          onMouseDown={handleMouseDown}
-          onMouseMove={handleMouseMove}
-          onMouseUp={handleMouseUp}
-          onMouseLeave={handleMouseLeave}
-          onTouchStart={(e) => {
-            e.preventDefault();
-            const touch = e.touches[0];
-            handleMouseDown({ clientX: touch.clientX, clientY: touch.clientY });
-          }}
-          onTouchMove={(e) => {
-            e.preventDefault();
-            const touch = e.touches[0];
-            handleMouseMove({ clientX: touch.clientX, clientY: touch.clientY });
-          }}
-          onTouchEnd={(e) => {
-            e.preventDefault();
-            const touch = e.changedTouches[0];
-            handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
-          }}
-        />
-      </div>
+      {/* Canvas fills all remaining vertical space as a direct flex child */}
+      <canvas
+        ref={canvasRef}
+        style={{ cursor: 'crosshair', display: 'block', flex: 1, minHeight: 0, touchAction: 'manipulation' }}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+        onTouchStart={(e) => {
+          e.preventDefault();
+          const touch = e.touches[0];
+          touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+          handleMouseDown({ clientX: touch.clientX, clientY: touch.clientY });
+        }}
+        onTouchMove={(e) => {
+          e.preventDefault();
+          const touch = e.touches[0];
+          const dx = touch.clientX - (touchStartRef.current?.x ?? touch.clientX);
+          const dy = touch.clientY - (touchStartRef.current?.y ?? touch.clientY);
+          const isHorizontalSwipe = Math.abs(dx) > Math.abs(dy) * 1.5 && Math.abs(dx) > 10;
+
+          if (isHorizontalSwipe && onRangeChange) {
+            const panFraction = -dx / dims.w * 0.5;
+            const panAmount = range * panFraction;
+            const newStart = startTs + panAmount;
+            const newEnd = endTs + panAmount;
+            const now = nowTs();
+            if (newEnd <= now && newEnd - newStart >= MIN_RANGE_SEC) {
+              onRangeChange(newStart, newEnd);
+            }
+            touchStartRef.current = { x: touch.clientX, y: touch.clientY };
+            return;
+          }
+
+          handleMouseMove({ clientX: touch.clientX, clientY: touch.clientY });
+        }}
+        onTouchEnd={(e) => {
+          e.preventDefault();
+          const touch = e.changedTouches[0];
+          handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
+        }}
+      />
 
       {/* Zoom control strip */}
       <div

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -22,6 +22,14 @@ import { useRef, useEffect, useState, useCallback } from 'react';
 import Hls from 'hls.js';
 import { formatTime } from '../utils/time.js';
 
+const LABEL_COLORS = {
+  person: '#4CAF50',
+  car: '#2196F3',
+  dog: '#FF9800',
+  cat: '#9C27B0',
+  default: '#607D8B',
+};
+
 const HLS_CONFIG = {
   enableWorker: true,
   lowLatencyMode: false,
@@ -37,6 +45,9 @@ export default function VideoPlayer({
   onTimeUpdate,
   onSegmentAdvance,
   scrubPreviewUrl,
+  isMobile = false,
+  eventSnapshot = null,
+  onSeek = null,
 }) {
   const videoRef = useRef(null);
   const preloadRef = useRef(null);
@@ -49,6 +60,7 @@ export default function VideoPlayer({
   const [displayTime, setDisplayTime] = useState(null);
   const [error, setError] = useState(null);
   const [hlsMode, setHlsMode] = useState(false);
+  const [detailOpen, setDetailOpen] = useState(false);
 
   // Sticky-last-frame: only update displayedPreviewUrl when the new image loads.
   // This prevents black flashes between frames during rapid scrubbing.
@@ -255,8 +267,8 @@ export default function VideoPlayer({
   }, []);
 
   const hasTarget = playbackTarget != null;
-  const showOverlay = scrubPreviewUrl != null;
-  const showPlaceholder = !hasTarget && !showOverlay;
+  const showOverlay = scrubPreviewUrl != null && eventSnapshot == null;
+  const showPlaceholder = !hasTarget && !showOverlay && !eventSnapshot;
 
   return (
     <div
@@ -314,6 +326,52 @@ export default function VideoPlayer({
           </div>
         )}
 
+        {/* Event snapshot overlay — shown when navigating to an event */}
+        {eventSnapshot && (
+          <div style={{
+            position: 'absolute', inset: 0,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: '#000',
+          }}>
+            <img
+              src={eventSnapshot.url}
+              alt={eventSnapshot.label}
+              style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+            />
+            <div style={{
+              position: 'absolute', top: 10, left: 10,
+              background: 'rgba(0,0,0,0.75)',
+              border: `1px solid ${LABEL_COLORS[eventSnapshot.label] ?? LABEL_COLORS.default}`,
+              color: LABEL_COLORS[eventSnapshot.label] ?? LABEL_COLORS.default,
+              padding: '3px 10px', borderRadius: 12,
+              fontSize: 13, fontFamily: 'monospace',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}>
+              <span style={{
+                width: 7, height: 7, borderRadius: '50%',
+                background: LABEL_COLORS[eventSnapshot.label] ?? LABEL_COLORS.default,
+                display: 'inline-block',
+              }}/>
+              {eventSnapshot.label}
+              {eventSnapshot.score != null && (
+                <span style={{ color: '#888', fontSize: 11 }}>
+                  {Math.round(eventSnapshot.score * 100)}%
+                </span>
+              )}
+            </div>
+            <button
+              onClick={() => { if (onSeek && eventSnapshot) onSeek(eventSnapshot.ts); }}
+              style={{
+                position: 'absolute', top: 8, right: 8,
+                background: 'rgba(0,0,0,0.6)', border: '1px solid #333',
+                color: '#888', width: 28, height: 28, borderRadius: 14,
+                cursor: 'pointer', fontSize: 14,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}
+            >✕</button>
+          </div>
+        )}
+
         {/* Placeholder when no playback target and no preview overlay */}
         {showPlaceholder && (
           <div
@@ -341,7 +399,7 @@ export default function VideoPlayer({
         style={{
           display: 'flex',
           alignItems: 'center',
-          gap: 12,
+          gap: isMobile ? 8 : 12,
           padding: '8px 12px',
           background: '#111',
           borderTop: '1px solid #333',
@@ -355,27 +413,21 @@ export default function VideoPlayer({
             background: 'none',
             border: '1px solid #555',
             color: hasTarget ? '#fff' : '#555',
-            padding: '4px 16px',
+            padding: isMobile ? '10px 14px' : '4px 16px',
             borderRadius: 4,
             cursor: hasTarget ? 'pointer' : 'default',
             fontSize: 17,
+            minHeight: isMobile ? 44 : undefined,
+            flexShrink: 0,
           }}
         >
-          {isPlaying ? '⏸ Pause' : '▶ Play'}
+          {isPlaying ? '⏸' : '▶'}
+          {!isMobile && (isPlaying ? ' Pause' : ' Play')}
         </button>
 
         <span style={{ color: '#aaa', fontSize: 17, fontFamily: 'monospace' }}>
           {displayTime != null ? formatTime(displayTime) : '--:--:--'}
         </span>
-
-        {hasTarget && (
-          <span style={{ color: '#555', fontSize: 16, marginLeft: 'auto' }}>
-            segment {playbackTarget.segment_id}
-            {!hlsMode && playbackTarget.next_segment_id && ' → ' + playbackTarget.next_segment_id}
-            {' · '}
-            {camera}
-          </span>
-        )}
 
         {hasTarget && (
           <span
@@ -393,18 +445,61 @@ export default function VideoPlayer({
           </span>
         )}
 
+        {/* Desktop: segment info inline */}
+        {hasTarget && !isMobile && (
+          <span style={{ color: '#555', fontSize: 16, marginLeft: 'auto' }}>
+            segment {playbackTarget.segment_id}
+            {!hlsMode && playbackTarget.next_segment_id && ' → ' + playbackTarget.next_segment_id}
+            {' · '}
+            {camera}
+          </span>
+        )}
+
+        {/* Mobile: detail toggle button */}
+        {hasTarget && isMobile && (
+          <button
+            onClick={() => setDetailOpen((v) => !v)}
+            style={{
+              marginLeft: 'auto',
+              background: 'none',
+              border: '1px solid #333',
+              color: detailOpen ? '#aaa' : '#555',
+              width: 28, height: 28, borderRadius: 14,
+              cursor: 'pointer', fontSize: 14,
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >ⓘ</button>
+        )}
+
         {error && (
-          <span style={{ color: '#f44', fontSize: 16, marginLeft: 'auto' }}>
+          <span style={{ color: '#f44', fontSize: 16, marginLeft: isMobile ? 'auto' : undefined }}>
             {error}
           </span>
         )}
 
         {!hasTarget && !error && (
           <span style={{ color: '#555', fontSize: 16 }}>
-            Click timeline to seek
+            {isMobile ? 'Tap timeline' : 'Click timeline to seek'}
           </span>
         )}
       </div>
+
+      {/* Mobile detail drawer */}
+      {isMobile && (
+        <div style={{
+          maxHeight: detailOpen ? 60 : 0,
+          overflow: 'hidden',
+          transition: 'max-height 0.2s ease',
+          background: '#0a0c12',
+          padding: detailOpen ? '6px 12px' : '0 12px',
+          fontSize: 12,
+          color: '#555',
+          borderTop: detailOpen ? '1px solid #222' : 'none',
+        }}>
+          {hasTarget && `segment ${playbackTarget.segment_id} · ${camera}`}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -105,6 +105,11 @@ export function segmentStreamUrl(segmentId, offsetSec) {
   return base;
 }
 
+/** Build the URL for a Frigate event snapshot (proxied through backend). */
+export function eventSnapshotUrl(eventId) {
+  return `${API_BASE}/events/${eventId}/snapshot`;
+}
+
 /** GET /api/health */
 export async function fetchHealth() {
   return apiFetch('/health');


### PR DESCRIPTION
## Summary

**Mobile UX:**
- Collapsible header on mobile saves ~80px — collapses to single-line wordmark with `⋯` toggle for health stats (auto-collapses after 4s)
- Compact controls: camera selector shows name only, all buttons meet 44px tap target minimum, 16px font on select prevents iOS auto-zoom
- Segment info moved behind `ⓘ` tap toggle in player controls
- Single-line timestamp on mobile (time only, not date)
- Timeline stacks below video on mobile, flexes to fill remaining viewport height with 320px minimum
- Zoom strip always visible via flex column layout, never clipped
- Touch events wired for scrubbing on iOS; horizontal swipe pans the time range; swipe detection avoids double-tap zoom conflicts
- Adaptive tick density — interval auto-scales to canvas height, no more overlapping labels at any zoom level
- Canvas is a direct flex item (`flex: 1`) so ResizeObserver correctly reports flex-allocated dimensions

**Event features:**
- Dynamic label discovery from live event data — no hardcoded labels, works with custom Frigate models automatically
- Label filter pills with color-coded toggles, persisted to localStorage, global across cameras
- Segment bars tint from cool blue toward amber based on event density — hot periods visible during full-day timelapse scanning
- 3px colored dot next to each tick label when events occurred in that time bucket — passive awareness, zero clutter
- Prev/Next event navigation buttons step through filtered events, auto-pan range to keep target in view, wrap at ends
- Frigate event snapshots (best-confidence frame) displayed in video player when jumping to an event, with label/score badge and dismiss button. Proxied through backend for CORS safety and 24h caching.
- `has_snapshot` field added to `EventInfo` schema and event query
- SplitView unaffected; per-camera label preferences deferred (TODO comment added)

## Test plan
- [ ] Desktop: header/controls/timeline layout unchanged
- [ ] Mobile (≤768px): header collapses, `⋯` expands health stats and auto-hides after 4s
- [ ] Mobile: camera selector is full-width, name-only; all buttons ≥44px tall
- [ ] Mobile: timestamp shows time only (no date)
- [ ] Mobile: timeline stacks below video and fills remaining height
- [ ] Mobile: touch-scrub on timeline canvas works; horizontal swipe pans time range
- [ ] Desktop zoom strip present; mobile zoom buttons are 36px
- [ ] Label filter pills appear when events are present; toggle/all works; survives page reload
- [ ] Segment bars tint amber in periods with dense events
- [ ] Tick label dots appear in correct color for dominant event label
- [ ] Prev/next buttons navigate events and auto-center range
- [ ] Event snapshot overlay appears for events with `has_snapshot=true`; dismiss triggers seek
- [ ] `GET /api/events/{id}/snapshot` proxies Frigate JPEG with 24h cache header

🤖 Generated with [Claude Code](https://claude.com/claude-code)