### PR TITLE
feat: targeted reindex UI — scan by time window, bypassing stale scan_state

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -233,6 +233,65 @@ async def admin_status():
     }
 
 
+@router.post("/reindex")
+async def admin_reindex(since_hours: float = 72.0):
+    """Trigger a targeted reindex from a given number of hours ago.
+
+    Bypasses scan_state entirely — does a full directory walk of all
+    recording directories whose date/hour falls within the window.
+    This finds segments that were missed by the incremental scanner.
+
+    Args:
+        since_hours: How many hours back to scan. Default 72.
+
+    Returns SSE stream of progress.
+    """
+    from app.services.indexer import index_segments_since_async
+    import datetime as _dt
+
+    async def _generate():
+        since_ts = time.time() - (since_hours * 3600)
+        since_label = _dt.datetime.utcfromtimestamp(since_ts).strftime('%Y-%m-%d %H:%M')
+        yield _sse("line", f"Starting targeted reindex: last {since_hours:.0f}h "
+                           f"(since {since_label} UTC)")
+        try:
+            result = await index_segments_since_async(since_ts)
+            total = sum(result.values())
+            for camera, count in sorted(result.items()):
+                if count > 0:
+                    yield _sse("line", f"  {camera}: +{count} new segments")
+            yield _sse_json("done", {"returncode": 0, "total": total, "cameras": len(result)})
+        except Exception as exc:
+            log.exception("Reindex error: %s", exc)
+            yield _sse_json("error", {"returncode": -1, "msg": str(exc)})
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.post("/reset-scan-state")
+async def admin_reset_scan_state():
+    """Reset scan_state for all cameras, forcing a full rescan on next worker cycle.
+
+    Use this if targeted reindex doesn't find expected segments.
+    The next worker cycle (within scan_interval_sec seconds) will do a full
+    directory walk of all recordings.
+
+    WARNING: The full walk of 1.5M+ segments can take several minutes.
+    """
+    from app.models.database import get_db
+
+    async with get_db() as db:
+        await db.execute("DELETE FROM scan_state")
+        await db.commit()
+
+    log.info("Admin: scan_state reset — next worker cycle will do full rglob")
+    return {"reset": True, "message": "scan_state cleared — full rescan on next worker cycle"}
+
+
 @router.get("/logs/stream")
 async def admin_logs_stream(
     lines: int = 50,

--- a/backend/app/services/indexer.py
+++ b/backend/app/services/indexer.py
@@ -315,6 +315,141 @@ async def index_segments_async():
     return await loop.run_in_executor(None, index_segments_sync)
 
 
+def index_segments_since(
+    since_ts: float,
+    recordings_path: Path | None = None,
+    db_path: Path | None = None,
+) -> dict[str, int]:
+    """Index all segments newer than since_ts, bypassing scan_state.
+
+    Unlike index_segments_sync which uses mtime-based incremental scanning,
+    this function walks the directory tree by DATE and only enters directories
+    whose date/hour falls within [since_ts, now]. This guarantees it finds
+    any segments that the incremental scanner missed.
+
+    Returns {camera: new_segment_count}.
+    """
+    from app.models.database import init_db_sync
+    from datetime import timedelta
+
+    recordings_path = recordings_path or settings.frigate_recordings_path
+    db_path = db_path or settings.database_path
+    init_db_sync()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode=WAL")
+
+    # Get already-indexed paths so we can skip them quickly
+    existing = set(
+        row[0] for row in conn.execute("SELECT path FROM segments").fetchall()
+    )
+
+    root = recordings_path
+    if not root.is_dir():
+        conn.close()
+        return {}
+
+    # Build set of (date_str, hour_str) pairs that fall within our window
+    now = time.time()
+    since_dt = datetime.fromtimestamp(since_ts, tz=timezone.utc)
+    now_dt = datetime.fromtimestamp(now, tz=timezone.utc)
+
+    valid_hours: set[tuple[str, str]] = set()
+    cursor = since_dt.replace(minute=0, second=0, microsecond=0)
+    while cursor <= now_dt + timedelta(hours=1):
+        valid_hours.add((cursor.strftime("%Y-%m-%d"), cursor.strftime("%H")))
+        cursor += timedelta(hours=1)
+
+    valid_dates = {d for d, _h in valid_hours}
+
+    # Walk only the matching directories
+    mp4_files: list[Path] = []
+    try:
+        for day_entry in os.scandir(root):
+            if not day_entry.is_dir():
+                continue
+            if day_entry.name not in valid_dates:
+                continue
+            for hour_entry in os.scandir(day_entry.path):
+                if not hour_entry.is_dir():
+                    continue
+                if (day_entry.name, hour_entry.name) not in valid_hours:
+                    continue
+                for cam_entry in os.scandir(hour_entry.path):
+                    if not cam_entry.is_dir():
+                        continue
+                    for entry in os.scandir(cam_entry.path):
+                        if entry.name.endswith(".mp4") and entry.is_file():
+                            mp4_files.append(Path(entry.path))
+    except PermissionError as exc:
+        log.warning("Reindex scan permission error: %s", exc)
+
+    # Parse and filter to only new segments
+    new_segments = []
+    for mp4 in mp4_files:
+        rel = mp4.relative_to(root)
+        parsed = parse_segment_path(str(rel))
+        if parsed is None:
+            continue
+        if str(rel) in existing:
+            continue
+        new_segments.append({
+            **parsed,
+            "path": str(rel),
+            "abs_path": str(mp4),
+            "file_size": mp4.stat().st_size,
+        })
+
+    if not new_segments:
+        log.info("Targeted reindex: no new segments found in last %.0f hours",
+                 (now - since_ts) / 3600)
+        conn.close()
+        return {}
+
+    log.info("Targeted reindex: found %d new segments in last %.0f hours",
+             len(new_segments), (now - since_ts) / 3600)
+
+    now_ts = time.time()
+    camera_counts: dict[str, int] = {}
+    batch_size = 200
+
+    for i in range(0, len(new_segments), batch_size):
+        batch = new_segments[i:i + batch_size]
+        rows = []
+        for seg in batch:
+            rows.append((
+                seg["camera"],
+                seg["start_ts"],
+                seg["start_ts"] + 10.0,  # default duration — Frigate segments are ~10s
+                10.0,
+                seg["path"],
+                seg["file_size"],
+                now_ts,
+                0,  # previews_generated = pending
+            ))
+            camera_counts[seg["camera"]] = camera_counts.get(seg["camera"], 0) + 1
+
+        conn.executemany(
+            """INSERT OR IGNORE INTO segments
+               (camera, start_ts, end_ts, duration, path, file_size,
+                indexed_at, previews_generated)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+        conn.commit()
+        log.info("Reindex batch %d-%d / %d", i, i + len(batch), len(new_segments))
+
+    conn.close()
+    log.info("Targeted reindex complete: %s", camera_counts)
+    return camera_counts
+
+
+async def index_segments_since_async(since_ts: float) -> dict[str, int]:
+    """Async wrapper for targeted reindex — runs in thread pool."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, index_segments_since, since_ts)
+
+
 # CLI entry point
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -126,6 +126,187 @@ function ProgressTab() {
   );
 }
 
+// ── ReindexTab ────────────────────────────────────────────────────────────────
+const REINDEX_PRESETS = [
+  { label: 'Last 1h',  hours: 1,    description: 'Quick fix — finds segments from the last hour' },
+  { label: 'Today',    hours: null,  description: 'From midnight UTC today' },
+  { label: 'Last 24h', hours: 24,   description: 'Yesterday + today' },
+  { label: 'Last 72h', hours: 72,   description: 'Recommended starting point' },
+  { label: '7 days',   hours: 168,  description: 'Full week — slower' },
+  { label: '30 days',  hours: 720,  description: 'Full month — slow, run once' },
+];
+
+function ReindexTab() {
+  const [running, setRunning] = useState(false);
+  const [lines, setLines] = useState([]);
+  const [customHours, setCustomHours] = useState('');
+  const bottomRef = useRef(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines]);
+
+  async function runReindex(hours) {
+    if (running) return;
+    setRunning(true);
+    setLines([`▶ Reindexing last ${hours}h…`]);
+
+    try {
+      const res = await fetch(`${API}/reindex?since_hours=${hours}`, { method: 'POST' });
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const frames = buffer.split('\n\n');
+        buffer = frames.pop() ?? '';
+
+        for (const frame of frames) {
+          const eventMatch = frame.match(/^event: (\w+)/m);
+          const dataMatch = frame.match(/^data: (.+)/m);
+          if (!eventMatch || !dataMatch) continue;
+
+          const event = eventMatch[1];
+          const data = dataMatch[1];
+
+          if (event === 'line') {
+            setLines(prev => [...prev, data]);
+          } else if (event === 'done') {
+            try {
+              const parsed = JSON.parse(data);
+              setLines(prev => [
+                ...prev,
+                `✓ Complete: ${parsed.total} new segments across ${parsed.cameras} cameras`,
+              ]);
+            } catch {
+              setLines(prev => [...prev, '✓ Complete']);
+            }
+            setRunning(false);
+          } else if (event === 'error') {
+            try {
+              const parsed = JSON.parse(data);
+              setLines(prev => [...prev, `✗ Error: ${parsed.msg}`]);
+            } catch {
+              setLines(prev => [...prev, `✗ Error: ${data}`]);
+            }
+            setRunning(false);
+          }
+        }
+      }
+    } catch (err) {
+      setLines(prev => [...prev, `✗ Fetch error: ${err.message}`]);
+      setRunning(false);
+    }
+  }
+
+  function getTodayHours() {
+    const now = Date.now() / 1000;
+    const midnight = Math.floor(now / 86400) * 86400;
+    return Math.ceil((now - midnight) / 3600) + 1;
+  }
+
+  return (
+    <div style={{ padding: 12 }}>
+      <div style={{
+        fontSize: 11, color: '#666', marginBottom: 12, lineHeight: 1.6,
+        borderLeft: '2px solid #2a2d37', paddingLeft: 8,
+      }}>
+        Targeted reindex scans recording directories within a time window,
+        bypassing the incremental scanner. Use this when the timeline shows
+        gaps despite recordings existing in Frigate.
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 12 }}>
+        {REINDEX_PRESETS.map(({ label, hours, description }) => {
+          const resolvedHours = hours ?? getTodayHours();
+          return (
+            <button
+              key={label}
+              onClick={() => runReindex(resolvedHours)}
+              disabled={running}
+              style={{
+                background: '#13161f',
+                border: '1px solid #2a2d37',
+                borderRadius: 4,
+                padding: '8px 10px',
+                cursor: running ? 'not-allowed' : 'pointer',
+                opacity: running ? 0.5 : 1,
+                textAlign: 'left',
+              }}
+            >
+              <div style={{ color: '#4ecdc4', fontSize: 12, fontFamily: 'monospace', fontWeight: 600, marginBottom: 2 }}>
+                {label}
+              </div>
+              <div style={{ color: '#555', fontSize: 10 }}>
+                {description}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12,
+        padding: '8px 10px', background: '#13161f',
+        border: '1px solid #2a2d37', borderRadius: 4,
+      }}>
+        <span style={{ color: '#666', fontSize: 11, flexShrink: 0 }}>Custom:</span>
+        <input
+          type="number"
+          min="1"
+          max="8760"
+          value={customHours}
+          onChange={e => setCustomHours(e.target.value)}
+          placeholder="hours"
+          style={{
+            flex: 1, background: '#0a0c12', border: '1px solid #333',
+            borderRadius: 3, color: '#aaa', fontSize: 11,
+            padding: '3px 6px', fontFamily: 'monospace',
+          }}
+        />
+        <span style={{ color: '#555', fontSize: 11, flexShrink: 0 }}>hours</span>
+        <button
+          onClick={() => { const h = parseFloat(customHours); if (!isNaN(h) && h > 0) runReindex(h); }}
+          disabled={running || !customHours || isNaN(parseFloat(customHours))}
+          style={{
+            background: '#1a1d27', border: '1px solid #333', borderRadius: 3,
+            color: '#aaa', padding: '3px 10px', cursor: 'pointer',
+            fontSize: 11, fontFamily: 'monospace', flexShrink: 0,
+          }}
+        >
+          Go
+        </button>
+      </div>
+
+      {lines.length > 0 && (
+        <div style={{
+          background: '#0a0c12', border: '1px solid #1e2130', borderRadius: 4,
+          padding: '8px 10px', fontSize: 11, fontFamily: 'monospace',
+          maxHeight: 200, overflowY: 'auto',
+        }}>
+          {lines.map((line, i) => (
+            <div key={i} style={{
+              color: line.startsWith('✓') ? '#6bcb77'
+                   : line.startsWith('✗') ? '#ff6b6b'
+                   : line.startsWith('▶') ? '#4ecdc4'
+                   : line.startsWith('  ') ? '#888'
+                   : '#ccc',
+              lineHeight: 1.6,
+            }}>
+              {line}
+            </div>
+          ))}
+          {running && <div style={{ color: '#666', marginTop: 4 }}>Running…</div>}
+          <div ref={bottomRef} />
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ── LogPane ───────────────────────────────────────────────────────────────────
 function LogPane({ lines, isLive, filter, onFilterChange }) {
   const bottomRef = useRef(null);
@@ -385,7 +566,7 @@ export default function AdminPanel() {
             </div>
 
             <div style={s.tabs}>
-              {['logs', 'status', 'progress', 'script'].map((t) => (
+              {['logs', 'status', 'progress', 'reindex', 'script'].map((t) => (
                 <button
                   key={t}
                   onClick={() => setTab(t)}
@@ -418,6 +599,8 @@ export default function AdminPanel() {
           )}
 
           {tab === 'progress' && <ProgressTab />}
+
+          {tab === 'reindex' && <ReindexTab />}
 
           {tab === 'script' && (
             <div style={{ ...s.logOutput, height: 280 }}>


### PR DESCRIPTION
## Summary

- The incremental scanner uses directory mtime cutoffs stored in `scan_state`. Once a directory's mtime falls below the cutoff it is permanently skipped, causing historical recordings to be silently absent from the timeline even when the files exist on disk.
- New `POST /api/admin/reindex?since_hours=N` endpoint does a date/hour directory walk for only the requested window, bypassing `scan_state` entirely, and inserts any missing segments via `INSERT OR IGNORE`.
- New "Reindex" tab in the Ops panel with six prioritized presets (1h / Today / 24h / 72h / 7d / 30d) plus a custom hours input. SSE progress stream shows per-camera new segment counts as they land.
- Additional `POST /api/admin/reset-scan-state` endpoint clears all scan_state rows, forcing the next regular worker cycle to do a full rglob (nuclear fallback option).
- No changes to the existing worker or incremental scan logic.

## How it works

`index_segments_since(since_ts)` builds a set of `(date_str, hour_str)` pairs covering the requested window, then walks only those matching directories by name — not by mtime. This makes it immune to the stale-cutoff problem. New segments are batch-inserted with `INSERT OR IGNORE` so it's safe to run multiple times or concurrently with the normal worker.

## Test plan
- [ ] `POST /api/admin/reindex?since_hours=1` returns SSE stream, ends with `event: done`
- [ ] Running reindex on a window with no new segments returns `total: 0`
- [ ] Running reindex on a window with missing segments inserts them and shows per-camera counts
- [ ] `POST /api/admin/reset-scan-state` returns `{"reset": true}` and scan_state table is empty
- [ ] Ops panel "reindex" tab renders between "progress" and "script"
- [ ] Each preset button fires a request with the correct `since_hours` value
- [ ] "Today" preset correctly computes hours since midnight UTC
- [ ] Custom input rejects blank/zero/NaN; Go button disabled when invalid
- [ ] Output log auto-scrolls; ✓/✗/▶ lines are color-coded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)