### PR TITLE
feat: reindex progress bar + hamburger ops drawer

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -239,31 +239,74 @@ async def admin_reindex(since_hours: float = 72.0):
 
     Bypasses scan_state entirely — does a full directory walk of all
     recording directories whose date/hour falls within the window.
-    This finds segments that were missed by the incremental scanner.
-
-    Args:
-        since_hours: How many hours back to scan. Default 72.
-
-    Returns SSE stream of progress.
+    Streams SSE progress events: discovered, progress, done/error.
     """
-    from app.services.indexer import index_segments_since_async
+    import queue
+    import threading
     import datetime as _dt
+    from app.services.indexer import index_segments_since
 
-    async def _generate():
-        since_ts = time.time() - (since_hours * 3600)
-        since_label = _dt.datetime.utcfromtimestamp(since_ts).strftime('%Y-%m-%d %H:%M')
-        yield _sse("line", f"Starting targeted reindex: last {since_hours:.0f}h "
-                           f"(since {since_label} UTC)")
+    since_ts = time.time() - (since_hours * 3600)
+    progress_q: queue.Queue = queue.Queue()
+
+    def _progress(tag, done, total, extra):
+        progress_q.put({"tag": tag, "done": done, "total": total, "extra": extra})
+
+    def _run():
         try:
-            result = await index_segments_since_async(since_ts)
-            total = sum(result.values())
-            for camera, count in sorted(result.items()):
-                if count > 0:
-                    yield _sse("line", f"  {camera}: +{count} new segments")
-            yield _sse_json("done", {"returncode": 0, "total": total, "cameras": len(result)})
+            result = index_segments_since(since_ts, progress_callback=_progress)
+            progress_q.put({"tag": "__done__", "result": result})
         except Exception as exc:
             log.exception("Reindex error: %s", exc)
-            yield _sse_json("error", {"returncode": -1, "msg": str(exc)})
+            progress_q.put({"tag": "__error__", "msg": str(exc)})
+
+    thread = threading.Thread(target=_run, daemon=True)
+
+    async def _generate():
+        since_label = _dt.datetime.utcfromtimestamp(since_ts).strftime('%Y-%m-%d %H:%M')
+        yield _sse("line", f"Scanning last {since_hours:.0f}h "
+                           f"(since {since_label} UTC)...")
+        thread.start()
+
+        while True:
+            try:
+                msg = progress_q.get_nowait()
+            except queue.Empty:
+                await asyncio.sleep(0.1)
+                continue
+
+            tag = msg["tag"]
+
+            if tag == "__discovered__":
+                total = msg["total"]
+                by_camera = msg["extra"]
+                if total == 0:
+                    yield _sse("line", "No new segments found in this time window.")
+                else:
+                    yield _sse("line", f"Found {total} new segments to index:")
+                    for cam, count in sorted(by_camera.items()):
+                        yield _sse("line", f"  {cam}: {count} segments")
+                yield _sse_json("discovered", {"total": total, "by_camera": by_camera})
+
+            elif tag == "__batch__":
+                done = msg["done"]
+                total = msg["total"]
+                pct = int(done / total * 100) if total > 0 else 100
+                yield _sse_json("progress", {"done": done, "total": total, "pct": pct})
+
+            elif tag == "__done__":
+                result = msg["result"]
+                total = sum(result.values())
+                yield _sse_json("done", {
+                    "returncode": 0,
+                    "total": total,
+                    "cameras": len(result),
+                })
+                break
+
+            elif tag == "__error__":
+                yield _sse_json("error", {"returncode": -1, "msg": msg["msg"]})
+                break
 
     return StreamingResponse(
         _generate(),

--- a/backend/app/services/indexer.py
+++ b/backend/app/services/indexer.py
@@ -319,6 +319,7 @@ def index_segments_since(
     since_ts: float,
     recordings_path: Path | None = None,
     db_path: Path | None = None,
+    progress_callback=None,  # callable(tag, done, total, extra) | None
 ) -> dict[str, int]:
     """Index all segments newer than since_ts, bypassing scan_state.
 
@@ -326,6 +327,10 @@ def index_segments_since(
     this function walks the directory tree by DATE and only enters directories
     whose date/hour falls within [since_ts, now]. This guarantees it finds
     any segments that the incremental scanner missed.
+
+    progress_callback(tag, done, total, extra) is called:
+      - Once after discovery: tag="__discovered__", done=0, total=N, extra={camera: count}
+      - After each batch commit: tag="__batch__", done=processed_so_far, total=N, extra={}
 
     Returns {camera: new_segment_count}.
     """
@@ -403,15 +408,24 @@ def index_segments_since(
     if not new_segments:
         log.info("Targeted reindex: no new segments found in last %.0f hours",
                  (now - since_ts) / 3600)
+        if progress_callback:
+            progress_callback("__discovered__", 0, 0, {})
         conn.close()
         return {}
 
     log.info("Targeted reindex: found %d new segments in last %.0f hours",
              len(new_segments), (now - since_ts) / 3600)
 
+    if progress_callback:
+        by_camera: dict[str, int] = {}
+        for seg in new_segments:
+            by_camera[seg["camera"]] = by_camera.get(seg["camera"], 0) + 1
+        progress_callback("__discovered__", 0, len(new_segments), by_camera)
+
     now_ts = time.time()
     camera_counts: dict[str, int] = {}
     batch_size = 200
+    processed_so_far = 0
 
     for i in range(0, len(new_segments), batch_size):
         batch = new_segments[i:i + batch_size]
@@ -437,17 +451,22 @@ def index_segments_since(
             rows,
         )
         conn.commit()
+        processed_so_far += len(batch)
         log.info("Reindex batch %d-%d / %d", i, i + len(batch), len(new_segments))
+        if progress_callback:
+            progress_callback("__batch__", processed_so_far, len(new_segments), {})
 
     conn.close()
     log.info("Targeted reindex complete: %s", camera_counts)
     return camera_counts
 
 
-async def index_segments_since_async(since_ts: float) -> dict[str, int]:
+async def index_segments_since_async(since_ts: float, progress_callback=None) -> dict[str, int]:
     """Async wrapper for targeted reindex — runs in thread pool."""
+    import functools
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, index_segments_since, since_ts)
+    fn = functools.partial(index_segments_since, since_ts, progress_callback=progress_callback)
+    return await loop.run_in_executor(None, fn)
 
 
 # CLI entry point

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -105,6 +105,7 @@ function LabelFilterPills({ availableLabels, activeLabels, onToggle, onToggleAll
 
 export default function App() {
   const isMobile = useIsMobile();
+  const [opsOpen, setOpsOpen] = useState(false);
   const [cameras, setCameras] = useState([]);
   const [selectedCamera, setSelectedCamera] = useState(null);
   const [selectedCameras, setSelectedCameras] = useState([]);
@@ -123,6 +124,13 @@ export default function App() {
   const [rangeEnd, setRangeEnd] = useState(nowTs());
 
   const [gotoValue, setGotoValue] = useState(() => toDatetimeLocal(nowTs()));
+
+  // Escape key closes ops drawer
+  useEffect(() => {
+    const handler = (e) => { if (e.key === 'Escape') setOpsOpen(false); };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
 
   // Mobile header expand/collapse
   const [healthExpanded, setHealthExpanded] = useState(false);
@@ -397,10 +405,16 @@ export default function App() {
               }} />
               <span style={{ fontSize: 17, fontWeight: 600, color: '#e0e0e0' }}>Frigate</span>
             </div>
-            <button
-              onClick={() => setHealthExpanded(v => !v)}
-              style={{ background: 'none', border: 'none', color: '#666', fontSize: 18, cursor: 'pointer', padding: '0 4px' }}
-            >⋯</button>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                onClick={() => setHealthExpanded(v => !v)}
+                style={{ background: 'none', border: 'none', color: '#666', fontSize: 18, cursor: 'pointer', padding: '0 4px' }}
+              >⋯</button>
+              <button
+                onClick={() => setOpsOpen(true)}
+                style={{ background: 'none', border: 'none', color: '#666', fontSize: 20, cursor: 'pointer', padding: '0 4px' }}
+              >☰</button>
+            </div>
           </div>
           {healthExpanded && health && (
             <div style={{ fontSize: 13, color: '#888', paddingBottom: 4 }}>
@@ -413,28 +427,45 @@ export default function App() {
       ) : (
         <div style={styles.header}>
           <h1 style={styles.title}>Frigate Review Accelerator</h1>
-          {health && (
-            <div style={styles.healthBadge}>
-              <span
-                style={{
-                  display: 'inline-block',
-                  width: 8,
-                  height: 8,
-                  borderRadius: '50%',
-                  background: health.frigate_reachable ? '#4CAF50' : '#f44',
-                  marginRight: 6,
-                }}
-              />
-              {health.total_segments.toLocaleString()} segs
-              {' · '}
-              {health.total_previews.toLocaleString()} previews
-              {health.pending_previews > 0 && (
-                <span style={{ color: '#888' }}>
-                  {' · '}{health.pending_previews.toLocaleString()} pending
-                </span>
-              )}
-            </div>
-          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+            {health && (
+              <div style={styles.healthBadge}>
+                <span
+                  style={{
+                    display: 'inline-block',
+                    width: 8,
+                    height: 8,
+                    borderRadius: '50%',
+                    background: health.frigate_reachable ? '#4CAF50' : '#f44',
+                    marginRight: 6,
+                  }}
+                />
+                {health.total_segments.toLocaleString()} segs
+                {' · '}
+                {health.total_previews.toLocaleString()} previews
+                {health.pending_previews > 0 && (
+                  <span style={{ color: '#888' }}>
+                    {' · '}{health.pending_previews.toLocaleString()} pending
+                  </span>
+                )}
+              </div>
+            )}
+            <button
+              onClick={() => setOpsOpen(true)}
+              style={{
+                background: 'none',
+                border: '1px solid #2a2d37',
+                color: '#666',
+                borderRadius: 6,
+                padding: '4px 10px',
+                cursor: 'pointer',
+                fontSize: 16,
+                lineHeight: 1,
+                display: 'flex', alignItems: 'center', gap: 6,
+              }}
+              title="Ops panel"
+            >☰</button>
+          </div>
         </div>
       )}
 
@@ -718,7 +749,7 @@ export default function App() {
         </div>
       )}
 
-      <AdminPanel />
+      <AdminPanel open={opsOpen} onClose={() => setOpsOpen(false)} />
     </div>
   );
 }

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -1,10 +1,12 @@
 /**
  * AdminPanel — Operational controls and live log viewer.
  *
- * v2 additions:
- *   - Restart reconnect UX: detects network drop during restart, polls
- *     /api/health until the server is back, then shows "✓ Back online".
- *   - Progress tab: per-camera preview generation progress bars.
+ * Rendered as a full-height side drawer from the right, opened by the
+ * hamburger button in the app header. Accepts open/onClose props.
+ *
+ * v3 additions:
+ *   - Drawer layout replaces fixed bottom-right overlay
+ *   - Reindex tab with live progress bar (discovered + batch events)
  */
 
 import { useState, useEffect, useRef, useCallback } from 'react';
@@ -140,6 +142,8 @@ function ReindexTab() {
   const [running, setRunning] = useState(false);
   const [lines, setLines] = useState([]);
   const [customHours, setCustomHours] = useState('');
+  const [reindexProgress, setReindexProgress] = useState(null);
+  // null | { done: number, total: number, pct: number }
   const bottomRef = useRef(null);
 
   useEffect(() => {
@@ -150,6 +154,7 @@ function ReindexTab() {
     if (running) return;
     setRunning(true);
     setLines([`▶ Reindexing last ${hours}h…`]);
+    setReindexProgress(null);
 
     try {
       const res = await fetch(`${API}/reindex?since_hours=${hours}`, { method: 'POST' });
@@ -174,7 +179,20 @@ function ReindexTab() {
 
           if (event === 'line') {
             setLines(prev => [...prev, data]);
+          } else if (event === 'discovered') {
+            try {
+              const p = JSON.parse(data);
+              if (p.total > 0) {
+                setReindexProgress({ done: 0, total: p.total, pct: 0 });
+              }
+            } catch {}
+          } else if (event === 'progress') {
+            try {
+              const p = JSON.parse(data);
+              setReindexProgress({ done: p.done, total: p.total, pct: p.pct });
+            } catch {}
           } else if (event === 'done') {
+            setReindexProgress(prev => prev ? { ...prev, pct: 100, done: prev.total } : null);
             try {
               const parsed = JSON.parse(data);
               setLines(prev => [
@@ -218,6 +236,33 @@ function ReindexTab() {
         bypassing the incremental scanner. Use this when the timeline shows
         gaps despite recordings existing in Frigate.
       </div>
+
+      {/* Progress bar — visible after discovery */}
+      {reindexProgress && (
+        <div style={{ marginBottom: 12 }}>
+          <div style={{
+            display: 'flex', justifyContent: 'space-between',
+            marginBottom: 4, fontSize: 10, fontFamily: 'monospace', color: '#666',
+          }}>
+            <span>
+              {reindexProgress.done.toLocaleString()} / {reindexProgress.total.toLocaleString()} segments
+            </span>
+            <span>{reindexProgress.pct}%</span>
+          </div>
+          <div style={{
+            height: 6, background: '#1a1d27', borderRadius: 3,
+            overflow: 'hidden', border: '1px solid #2a2d37',
+          }}>
+            <div style={{
+              height: '100%',
+              width: `${reindexProgress.pct}%`,
+              background: reindexProgress.pct === 100 ? '#4CAF50' : '#4ecdc4',
+              borderRadius: 3,
+              transition: 'width 0.3s ease',
+            }} />
+          </div>
+        </div>
+      )}
 
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 12 }}>
         {REINDEX_PRESETS.map(({ label, hours, description }) => {
@@ -375,8 +420,7 @@ function LogPane({ lines, isLive, filter, onFilterChange }) {
 }
 
 // ── AdminPanel ────────────────────────────────────────────────────────────────
-export default function AdminPanel() {
-  const [open, setOpen] = useState(false);
+export default function AdminPanel({ open, onClose }) {
   const [tab, setTab] = useState('logs');
   const [status, setStatus] = useState(null);
   const [logLines, setLogLines] = useState([]);
@@ -512,14 +556,12 @@ export default function AdminPanel() {
       })
       .catch((err) => {
         if (isRestart) {
-          // Network drop during restart is expected — server killed itself
           setReconnecting(true);
           setScriptLines((prev) => [...prev, 'Server restarting… reconnecting']);
           startHealthPoll(() => {
             setReconnecting(false);
             setRunning(null);
             setScriptLines((prev) => [...prev, '✓ Back online']);
-            // Re-establish log stream
             if (tab === 'logs') connectLogStream();
           });
         } else {
@@ -530,59 +572,102 @@ export default function AdminPanel() {
   }, [running, tab, startHealthPoll, connectLogStream]);
 
   // ── Render ──────────────────────────────────────────────────────────────────
+  if (!open) return null;
+
   return (
-    <div style={s.wrapper}>
-      <button onClick={() => setOpen((v) => !v)} style={s.toggleBtn}>
-        {open ? '✕ Close Ops' : '⚙ Ops'}
-      </button>
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed', inset: 0,
+          background: 'rgba(0,0,0,0.4)',
+          zIndex: 999,
+        }}
+      />
+      {/* Drawer */}
+      <div style={{
+        position: 'fixed',
+        top: 0, right: 0,
+        width: Math.min(700, window.innerWidth),
+        height: '100vh',
+        background: '#0d1017',
+        border: '1px solid #2a2d37',
+        boxShadow: '-8px 0 32px rgba(0,0,0,0.6)',
+        zIndex: 1000,
+        display: 'flex',
+        flexDirection: 'column',
+        overflow: 'hidden',
+        fontFamily: 'monospace',
+        fontSize: 12,
+      }}>
+        {/* Drawer header */}
+        <div style={{
+          display: 'flex', alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          borderBottom: '1px solid #2a2d37',
+          background: '#13161f',
+          flexShrink: 0,
+        }}>
+          <span style={{ color: '#e0e0e0', fontWeight: 600, fontSize: 14 }}>
+            ⚙ Ops Panel
+          </span>
+          <button
+            onClick={onClose}
+            style={{
+              background: 'none', border: 'none',
+              color: '#666', fontSize: 20, cursor: 'pointer',
+              padding: '0 4px', lineHeight: 1,
+            }}
+          >✕</button>
+        </div>
 
-      {open && (
-        <div style={s.panel}>
-          <div style={s.panelHeader}>
-            <span style={s.panelTitle}>Ops Panel</span>
+        {/* Action buttons */}
+        <div style={{ ...s.actionRow, padding: '10px 14px', flexShrink: 0 }}>
+          {[
+            { id: 'restart', label: '↺ Restart backend', color: '#4ecdc4' },
+            { id: 'update',  label: '↑ Update deps',     color: '#ffd93d' },
+            { id: 'pull',    label: '⬇ Git pull',        color: '#c77dff' },
+          ].map(({ id, label, color }) => (
+            <button
+              key={id}
+              onClick={() => runScript(id)}
+              disabled={!!running}
+              style={{
+                ...s.actionBtn,
+                borderColor: color,
+                color: running === id ? color : '#888',
+                opacity: running && running !== id ? 0.4 : 1,
+              }}
+            >
+              {running === id
+                ? reconnecting ? 'Reconnecting…' : `${label}…`
+                : label}
+            </button>
+          ))}
+        </div>
 
-            <div style={s.actionRow}>
-              {[
-                { id: 'restart', label: '↺ Restart backend', color: '#4ecdc4' },
-                { id: 'update',  label: '↑ Update deps',     color: '#ffd93d' },
-                { id: 'pull',    label: '⬇ Git pull',        color: '#c77dff' },
-              ].map(({ id, label, color }) => (
-                <button
-                  key={id}
-                  onClick={() => runScript(id)}
-                  disabled={!!running}
-                  style={{
-                    ...s.actionBtn,
-                    borderColor: color,
-                    color: running === id ? color : '#888',
-                    opacity: running && running !== id ? 0.4 : 1,
-                  }}
-                >
-                  {running === id
-                    ? reconnecting ? 'Reconnecting…' : `${label}…`
-                    : label}
-                </button>
-              ))}
-            </div>
+        {/* Tab strip */}
+        <div style={{ ...s.tabs, borderBottom: '1px solid #2a2d37', flexShrink: 0 }}>
+          {['logs', 'status', 'progress', 'reindex', 'script'].map((t) => (
+            <button
+              key={t}
+              onClick={() => setTab(t)}
+              style={{
+                ...s.tab,
+                borderBottom: tab === t ? '2px solid #4ecdc4' : '2px solid transparent',
+                color: tab === t ? '#4ecdc4' : '#666',
+              }}
+            >
+              {t}
+              {t === 'script' && running && <span style={s.runningDot} />}
+            </button>
+          ))}
+        </div>
 
-            <div style={s.tabs}>
-              {['logs', 'status', 'progress', 'reindex', 'script'].map((t) => (
-                <button
-                  key={t}
-                  onClick={() => setTab(t)}
-                  style={{
-                    ...s.tab,
-                    borderBottom: tab === t ? '2px solid #4ecdc4' : '2px solid transparent',
-                    color: tab === t ? '#4ecdc4' : '#666',
-                  }}
-                >
-                  {t}
-                  {t === 'script' && running && <span style={s.runningDot} />}
-                </button>
-              ))}
-            </div>
-          </div>
-
+        {/* Tab content — scrollable */}
+        <div style={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
           {tab === 'logs' && (
             <LogPane
               lines={logLines}
@@ -603,7 +688,7 @@ export default function AdminPanel() {
           {tab === 'reindex' && <ReindexTab />}
 
           {tab === 'script' && (
-            <div style={{ ...s.logOutput, height: 280 }}>
+            <div style={{ ...s.logOutput, flex: 1 }}>
               {scriptLines.map((line, i) => (
                 <div
                   key={i}
@@ -628,61 +713,14 @@ export default function AdminPanel() {
             </div>
           )}
         </div>
-      )}
-    </div>
+      </div>
+    </>
   );
 }
 
 // ── Styles ────────────────────────────────────────────────────────────────────
 const s = {
-  wrapper: {
-    position: 'fixed',
-    bottom: 0,
-    right: 0,
-    zIndex: 1000,
-    fontFamily: 'monospace',
-    fontSize: 12,
-  },
-  toggleBtn: {
-    position: 'absolute',
-    bottom: 12,
-    right: 12,
-    background: '#1a1d27',
-    border: '1px solid #333',
-    color: '#aaa',
-    padding: '6px 14px',
-    borderRadius: 6,
-    cursor: 'pointer',
-    fontSize: 12,
-    fontFamily: 'monospace',
-  },
-  panel: {
-    position: 'fixed',
-    bottom: 48,
-    right: 12,
-    width: 680,
-    maxWidth: 'calc(100vw - 24px)',
-    background: '#0d1017',
-    border: '1px solid #2a2d37',
-    borderRadius: 8,
-    boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
-    display: 'flex',
-    flexDirection: 'column',
-    overflow: 'hidden',
-  },
-  panelHeader: {
-    background: '#13161f',
-    borderBottom: '1px solid #2a2d37',
-    padding: '10px 14px 0',
-  },
-  panelTitle: {
-    color: '#e0e0e0',
-    fontWeight: 600,
-    fontSize: 13,
-    display: 'block',
-    marginBottom: 8,
-  },
-  actionRow: { display: 'flex', gap: 8, marginBottom: 10 },
+  actionRow: { display: 'flex', gap: 8 },
   actionBtn: {
     background: 'transparent',
     border: '1px solid',
@@ -693,7 +731,7 @@ const s = {
     fontFamily: 'monospace',
     transition: 'opacity 0.15s',
   },
-  tabs: { display: 'flex', gap: 0 },
+  tabs: { display: 'flex', gap: 0, background: '#13161f' },
   tab: {
     background: 'transparent',
     border: 'none',
@@ -703,7 +741,7 @@ const s = {
     fontFamily: 'monospace',
     position: 'relative',
   },
-  logWrapper: { display: 'flex', flexDirection: 'column', height: 320 },
+  logWrapper: { display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' },
   logToolbar: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -711,6 +749,7 @@ const s = {
     padding: '6px 10px',
     borderBottom: '1px solid #1a1d27',
     background: '#0f1117',
+    flexShrink: 0,
   },
   filterButtons: { display: 'flex', gap: 4 },
   filterBtn: {
@@ -732,7 +771,7 @@ const s = {
     fontSize: 11,
     lineHeight: '1.6',
   },
-  statusPane: { padding: 14, overflowY: 'auto', maxHeight: 320 },
+  statusPane: { padding: 14, overflowY: 'auto', flex: 1 },
   statusGrid: { display: 'flex', flexDirection: 'column', gap: 8 },
   statusRow: {
     display: 'flex',


### PR DESCRIPTION
## Summary

**Reindex progress bar:**
- `index_segments_since()` now accepts a `progress_callback(tag, done, total, extra)` called once after the filesystem walk (`__discovered__`) and after each 200-segment batch commit (`__batch__`)
- `admin_reindex` endpoint replaced with a thread+queue pattern: the indexer runs in a daemon thread, progress items are polled via `asyncio.sleep(0.1)` and forwarded as typed SSE frames (`discovered`, `progress`, `done`, `error`)
- `ReindexTab` handles the new frames: a live progress bar appears immediately after discovery and fills 0→100% with a segment count readout. The "Running…" placeholder is replaced by real feedback from the first SSE frame.

**Hamburger ops drawer:**
- `AdminPanel` is now a controlled component accepting `open`/`onClose` props
- Renders as a full-height right-side drawer with a semi-transparent backdrop
- Closes via ✕ button, backdrop click, or Escape key
- Fixed bottom-right toggle button and `position: fixed` wrapper removed entirely
- `App.jsx` adds `opsOpen` state, a `☰` button in the desktop header (right of health badge), and a `☰` button alongside the existing `⋯` in the mobile header row
- All existing panel tabs (logs, status, progress, reindex, script) unchanged inside the drawer

## Test plan
- [ ] Desktop: `☰` button appears in header, clicking opens drawer
- [ ] Mobile: `☰` button appears in header row alongside `⋯`
- [ ] Drawer closes on ✕, backdrop click, and Escape key
- [ ] All five tabs render correctly inside the drawer
- [ ] Script tab still handles restart reconnect flow
- [ ] Reindex: running a preset shows "Scanning…" line immediately
- [ ] After discovery, progress bar appears with correct total
- [ ] Progress bar fills as batches complete; turns green at 100%
- [ ] Running on an empty window shows "No new segments found" with no progress bar
- [ ] Old fixed-position Ops button is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)