### PR TITLE
fix: snap scrub cursor to nearest segment coverage, skip gaps

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -50,6 +50,33 @@ const LABEL_COLORS = {
   default: '#607D8B',
 };
 
+/**
+ * Snap a timestamp to the nearest covered position in a sorted segment array.
+ *
+ * If ts falls inside a segment: returned as-is (fine-grained scrub still works).
+ * If ts falls in a gap: returns the nearest segment edge so the preview and
+ * cursor always land on actual footage, regardless of zoom level.
+ *
+ * Binary search — O(log n) even across 1.5M segments.
+ */
+function snapToCoverage(ts, segments) {
+  if (!segments?.length) return ts;
+  let lo = 0, hi = segments.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const seg = segments[mid];
+    if (ts < seg.start_ts) hi = mid - 1;
+    else if (ts > seg.end_ts) lo = mid + 1;
+    else return ts; // inside a segment — no snap needed
+  }
+  // In a gap: lo = index of first segment after ts
+  const prev = lo > 0 ? segments[lo - 1] : null;
+  const next = lo < segments.length ? segments[lo] : null;
+  if (!prev) return next.start_ts;
+  if (!next) return prev.end_ts;
+  return (ts - prev.end_ts) <= (next.start_ts - ts) ? prev.end_ts : next.start_ts;
+}
+
 /** Format a Unix timestamp for a datetime-local input value. */
 function toDatetimeLocal(ts) {
   const d = new Date(ts * 1000);
@@ -226,10 +253,12 @@ export default function App() {
   }, []);
 
   // ─── Scrub handler: sets hover position + moves cursor line ───
+  // Snaps to nearest covered segment so preview and cursor never land in a gap.
   const handleScrub = useCallback((ts) => {
-    setHoverTs(ts);
-    setCursorTs(ts);
-  }, []);
+    const snapped = snapToCoverage(ts, timelineData?.segments);
+    setHoverTs(snapped);
+    setCursorTs(snapped);
+  }, [timelineData]);
 
   // ─── Scrub end: clear hover (cursor stays at last position) ───
   const handleScrubEnd = useCallback(() => {


### PR DESCRIPTION
## Summary

- Adds `snapToCoverage(ts, segments)` — an O(log n) binary search that finds whether a timestamp falls inside a recorded segment or in a gap
- When scrubbing lands in a gap, snaps to the nearest segment edge (`prev.end_ts` or `next.start_ts`, whichever is closer)
- Applied in `handleScrub` so both the preview image URL (`hoverTs`) and the red cursor line (`cursorTs`) always land on actual footage

## Why this was broken

The timeline canvas maps pixel position to a raw timestamp linearly. At wide zoom levels (e.g. 8h or 24h view), gaps between recordings can span many seconds or even minutes. `handleScrub` passed the raw canvas timestamp directly to state, so:

- The preview image URL pointed at a timestamp with no `.jpg` file → blank image
- The cursor readout showed time jumping through dead, unrecorded time

## What changed

**`frontend/src/App.jsx`** — 32 lines added:

```js
function snapToCoverage(ts, segments) {
  if (!segments?.length) return ts;
  let lo = 0, hi = segments.length - 1;
  while (lo <= hi) {
    const mid = (lo + hi) >> 1;
    const seg = segments[mid];
    if (ts < seg.start_ts) hi = mid - 1;
    else if (ts > seg.end_ts) lo = mid + 1;
    else return ts;  // inside a segment — no snap needed
  }
  // ts is in a gap; lo points to the next segment, lo-1 to the previous
  const prev = lo > 0 ? segments[lo - 1] : null;
  const next = lo < segments.length ? segments[lo] : null;
  if (!prev) return next.start_ts;
  if (!next) return prev.end_ts;
  return (ts - prev.end_ts) <= (next.start_ts - ts) ? prev.end_ts : next.start_ts;
}
```

`handleScrub` now passes the raw timestamp through `snapToCoverage` before setting state. `handleSeek` (click-to-play) is unchanged — the backend's `/api/playback` already finds the nearest segment.

## Behavior

| Zoom | Before | After |
|------|--------|-------|
| Narrow (1h) | Mostly fine — gaps are pixels wide | No change |
| Wide (8h–24h) | Cursor drifts through minutes of dead time, image blanks | Cursor jumps cleanly to nearest footage edge |

## Test plan

- [ ] Scrub slowly across a known gap at 8h zoom — cursor should snap between segment edges without blanking
- [ ] Scrub within a segment — smooth 2s preview resolution, no change in behavior
- [ ] Seek (click) in a gap — video should still start at the nearest segment (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)