### PR TITLE
fix(admin): restart reconnect now fires on stream drop, not just fetch rejection

### DIFF
--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -451,6 +451,11 @@ export default function AdminPanel({ open, onClose }) {
     return () => clearInterval(interval);
   }, [open]);
 
+  // ── Clear health poll on unmount ────────────────────────────────────────────
+  useEffect(() => {
+    return () => { if (healthPollRef.current) clearInterval(healthPollRef.current); };
+  }, []);
+
   // ── Log SSE stream ──────────────────────────────────────────────────────────
   const connectLogStream = useCallback(() => {
     if (sseRef.current) sseRef.current.close();
@@ -517,63 +522,89 @@ export default function AdminPanel({ open, onClose }) {
 
     const isRestart = action === 'restart';
 
+    // Shared reconnect path — used by stream errors, clean EOF without a
+    // done event, and outer fetch rejections (e.g. network down before 200).
+    const triggerReconnect = () => {
+      setReconnecting(true);
+      setScriptLines((prev) => [...prev, 'Server restarting… reconnecting']);
+      startHealthPoll(() => {
+        setReconnecting(false);
+        setRunning(null);
+        setScriptLines((prev) => [...prev, '✓ Back online']);
+        if (tab === 'logs') connectLogStream();
+      });
+    };
+
     fetch(`${API}/${action}`, { method: 'POST' })
       .then(async (res) => {
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
         let buffer = '';
+        let gotDoneEvent = false;
 
-        while (true) {
-          const { value, done } = await reader.read();
-          if (done) break;
+        try {
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
 
-          buffer += decoder.decode(value, { stream: true });
-          const frames = buffer.split('\n\n');
-          buffer = frames.pop() ?? '';
+            buffer += decoder.decode(value, { stream: true });
+            const frames = buffer.split('\n\n');
+            buffer = frames.pop() ?? '';
 
-          for (const frame of frames) {
-            const eventMatch = frame.match(/^event: (\w+)/m);
-            const dataMatch  = frame.match(/^data: (.+)/m);
-            if (!eventMatch || !dataMatch) continue;
+            for (const frame of frames) {
+              const eventMatch = frame.match(/^event: (\w+)/m);
+              const dataMatch  = frame.match(/^data: (.+)/m);
+              if (!eventMatch || !dataMatch) continue;
 
-            const event = eventMatch[1];
-            const data  = dataMatch[1];
+              const event = eventMatch[1];
+              const data  = dataMatch[1];
 
-            if (event === 'line') {
-              setScriptLines((prev) => [...prev, data]);
-            } else if (event === 'done') {
-              let returncode = 0;
-              try { returncode = JSON.parse(data).returncode ?? 0; } catch {}
-              if ((action === 'update' || action === 'pull') && returncode === 0) {
-                setScriptLines((prev) => [...prev, '✓ Update complete. Restart required to apply changes.']);
-                setRunning(null);
-                setPendingRestart({ countdown: 5 });
-              } else {
-                setScriptLines((prev) => [...prev, '✓ Done.']);
+              if (event === 'line') {
+                setScriptLines((prev) => [...prev, data]);
+              } else if (event === 'done') {
+                gotDoneEvent = true;
+                let returncode = 0;
+                try { returncode = JSON.parse(data).returncode ?? 0; } catch {}
+                if ((action === 'update' || action === 'pull') && returncode === 0) {
+                  setScriptLines((prev) => [...prev, '✓ Update complete. Restart required to apply changes.']);
+                  setRunning(null);
+                  setPendingRestart({ countdown: 5 });
+                } else {
+                  setScriptLines((prev) => [...prev, '✓ Done.']);
+                  setRunning(null);
+                }
+              } else if (event === 'error') {
+                try {
+                  const parsed = JSON.parse(data);
+                  setScriptLines((prev) => [...prev, `✗ Error: ${parsed.msg}`]);
+                } catch {
+                  setScriptLines((prev) => [...prev, `✗ Error: ${data}`]);
+                }
                 setRunning(null);
               }
-            } else if (event === 'error') {
-              try {
-                const parsed = JSON.parse(data);
-                setScriptLines((prev) => [...prev, `✗ Error: ${parsed.msg}`]);
-              } catch {
-                setScriptLines((prev) => [...prev, `✗ Error: ${data}`]);
-              }
-              setRunning(null);
             }
           }
+        } catch {
+          // reader.read() threw — connection dropped mid-stream.
+          if (isRestart) {
+            triggerReconnect();
+          } else {
+            setScriptLines((prev) => [...prev, '✗ Connection lost.']);
+            setRunning(null);
+          }
+          return;
+        }
+
+        // Stream ended cleanly (done=true) but no `done` SSE event was received.
+        // This happens when uvicorn exits before it can flush the final frame.
+        if (isRestart && !gotDoneEvent) {
+          triggerReconnect();
         }
       })
       .catch((err) => {
+        // fetch() itself rejected — network error before any response bytes.
         if (isRestart) {
-          setReconnecting(true);
-          setScriptLines((prev) => [...prev, 'Server restarting… reconnecting']);
-          startHealthPoll(() => {
-            setReconnecting(false);
-            setRunning(null);
-            setScriptLines((prev) => [...prev, '✓ Back online']);
-            if (tab === 'logs') connectLogStream();
-          });
+          triggerReconnect();
         } else {
           setScriptLines((prev) => [...prev, `✗ Fetch error: ${err.message}`]);
           setRunning(null);


### PR DESCRIPTION
## Root cause

`fetch()` resolves as soon as the HTTP 200 response header arrives — long before the SSE body is streamed. The `.catch()` on the outer promise chain therefore only fires if the TCP connection fails *before* any response bytes.

Once execution enters `.then(async (res) => {...})`, we're reading the SSE body through `res.body.getReader()`. When uvicorn dies, one of two things happens:

| Scenario | What reader.read() does | Previous behaviour |
|----------|-------------------------|--------------------|
| uvicorn exits before flushing final SSE frame | Returns `{ done: true }` (clean EOF) | Loop breaks, `.then()` resolves normally, `.catch()` never reached → **silent** |
| Connection severed mid-stream | Throws `TypeError: network error` | Exception propagates to `.catch()` → reconnect **did** fire (but only in this rarer case) |

In practice, the clean-EOF case is by far the most common: uvicorn gets SIGTERM, flushes buffers, and closes the socket before `restart.sh` has a chance to write a final SSE frame. So **the reconnect path was almost never triggered**.

## What was broken

After clicking "↺ Restart backend":
- Script lines stopped appearing mid-stream
- `running` state was left as `'restart'` forever (buttons locked)  
- `reconnecting` was never set → no "Reconnecting…" banner
- `startHealthPoll` was never called → no "✓ Back online" when uvicorn came back

## Fix

Three changes to `runScript`:

**1. Wrap reader loop in try/catch**
```js
try {
  while (true) {
    const { value, done } = await reader.read();
    if (done) break;
    // ... parse SSE ...
  }
} catch {
  if (isRestart) { triggerReconnect(); return; }
  else { setScriptLines(prev => [...prev, '✗ Connection lost.']); setRunning(null); return; }
}
```

**2. Check for clean EOF without a `done` SSE event**
```js
// After the loop exits normally:
if (isRestart && !gotDoneEvent) {
  triggerReconnect();
}
```

**3. Extract `triggerReconnect()` as a shared local function**

Previously the reconnect body was duplicated in `.catch()`. Now all three code paths (inner catch, post-loop check, outer fetch rejection) call the same `triggerReconnect()`. No behavioral difference for the rare "fetch rejected before 200" case.

**4. Unmount cleanup for healthPollRef**

Added a `useEffect(() => () => clearInterval(healthPollRef.current), [])` so a stale health-poll interval can't fire after the drawer is closed while a reconnect is in progress.

## Unchanged

- `update` and `pull` actions: stream errors show an error message, no reconnect attempt
- Restart action UX after reconnect succeeds: "✓ Back online" + log stream reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)