### PR TITLE
fix: restart.sh survives SIGPIPE when invoked from uvicorn SSE pipe

### DIFF
--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -19,6 +19,13 @@
 
 set -euo pipefail
 
+# When this script is invoked from the admin SSE endpoint, its stdout is
+# connected to uvicorn's asyncio pipe reader.  Step 1 of a backend restart
+# is killing uvicorn, which closes that pipe's read end.  Without this trap,
+# the next echo/info call produces EPIPE → SIGPIPE, and set -e exits the
+# script before the new uvicorn process is ever started.
+trap '' PIPE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BACKEND_DIR="$PROJECT_ROOT/backend"
@@ -31,10 +38,12 @@ mkdir -p "$LOG_DIR" "$PID_DIR"
 
 # ── Colour helpers ────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
-info()    { echo -e "${GREEN}[restart]${NC} $*"; }
-warn()    { echo -e "${YELLOW}[restart]${NC} $*"; }
-error()   { echo -e "${RED}[restart]${NC} $*" >&2; }
-section() { echo -e "\n${CYAN}── $* ──${NC}"; }
+# '|| true' prevents set -e from triggering if the write end of the pipe is
+# closed (e.g. when uvicorn dies mid-restart and nobody reads our stdout).
+info()    { echo -e "${GREEN}[restart]${NC} $*" || true; }
+warn()    { echo -e "${YELLOW}[restart]${NC} $*" || true; }
+error()   { echo -e "${RED}[restart]${NC} $*" >&2 || true; }
+section() { echo -e "\n${CYAN}── $* ──${NC}" || true; }
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
 DO_BACKEND=true
@@ -173,7 +182,7 @@ fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 if $DO_START; then
-  echo ""
+  echo "" || true
   info "All services running. Tail logs with:"
-  echo "       ./scripts/logs.sh"
+  echo "       ./scripts/logs.sh" || true
 fi


### PR DESCRIPTION
## What broke and why

The admin panel's **↺ Restart backend** button calls `POST /api/admin/restart`, which runs `restart.sh --backend` via `asyncio.create_subprocess_exec` with `stdout=asyncio.subprocess.PIPE`. This connects the script's stdout directly to uvicorn's asyncio pipe reader so output can be streamed as SSE.

Step 1 of `restart.sh` is killing the currently-running uvicorn process. When uvicorn dies (or begins graceful shutdown), its asyncio event loop stops consuming the pipe, and the **read end of the pipe is closed**.

The script's next `info`/`echo` call then fails:

1. The OS delivers **`SIGPIPE`** to the bash process.
2. If SIGPIPE is caught/ignored, `write()` returns **`EPIPE`** (errno 32), and `echo` returns non-zero.
3. `restart.sh` has `set -euo pipefail` at the top — **any non-zero return exits the script immediately**.

The script dies at the first `info "Starting uvicorn..."` line, before `nohup uvicorn` is ever executed. No new backend process is started. The frontend polls `/api/health` forever and shows "Backend unreachable".

## How to reproduce

1. Open the admin panel, click **↺ Restart backend**.
2. Script output appears briefly ("Stopping backend…"), then nothing.
3. `/api/health` never responds again — uvicorn is dead and the new one was never started.

## Fix

Two complementary changes in `restart.sh`:

**1. Suppress SIGPIPE (`trap '' PIPE`)**

Added immediately after `set -euo pipefail`. Prevents the OS from sending SIGPIPE to the process when writing to a closed pipe.

**2. `|| true` on all echo calls in helper functions**

With SIGPIPE suppressed, `write()` still returns `EPIPE`, causing `echo` to return non-zero. `set -e` would still fire. Adding `|| true` to every `echo` in `info()`/`warn()`/`error()`/`section()` prevents this — the script silently swallows broken-pipe write failures and continues to the `nohup uvicorn` startup.

```bash
# Before
info()    { echo -e "${GREEN}[restart]${NC} $*"; }

# After
trap '' PIPE
info()    { echo -e "${GREEN}[restart]${NC} $*" || true; }
```

## What's unchanged

- All logic and exit codes are the same.
- The 2-second health check after uvicorn start still works.
- Output is still streamed as SSE when the pipe is alive (before uvicorn is killed). After the kill, writes silently no-op.
- `update.sh` and `frontend` restart path are unaffected.

## Verification

All 71 unit + integration tests pass. The backend code itself has no bugs — this was purely a shell script / process-model issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)