### PR TITLE
fix(player): dismiss event snapshot overlay when playback starts

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -685,6 +685,7 @@ export default function App() {
                 isMobile={isMobile}
                 eventSnapshot={activeEventSnapshot}
                 onSeek={handleSeek}
+                onPlaybackStart={() => setActiveEventSnapshot(null)}
               />
             </div>
 

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -48,6 +48,7 @@ export default function VideoPlayer({
   isMobile = false,
   eventSnapshot = null,
   onSeek = null,
+  onPlaybackStart = null,
 }) {
   const videoRef = useRef(null);
   const preloadRef = useRef(null);
@@ -295,7 +296,10 @@ export default function VideoPlayer({
           onTimeUpdate={handleTimeUpdate}
           onError={handleError}
           onEnded={handleEnded}
-          onPlay={() => setIsPlaying(true)}
+          onPlay={() => {
+            setIsPlaying(true);
+            if (onPlaybackStart) onPlaybackStart();
+          }}
           onPause={() => setIsPlaying(false)}
           playsInline
           muted


### PR DESCRIPTION
## Summary

- Add `onPlaybackStart` prop (optional callback) to `VideoPlayer` — fires from the `<video>` element's `onPlay` event
- `App.jsx` passes `() => setActiveEventSnapshot(null)` so the snapshot overlay clears the moment video playback actually begins
- ✕ button path was already correct: `handleSeek` in `App.jsx` calls `setActiveEventSnapshot(null)` at line 274 before setting a new playback target — verified, no change needed there

## Behaviour matrix

| Action | Before | After |
|---|---|---|
| Event snapshot shown | overlay visible | overlay visible ✓ |
| User clicks Play | video plays *behind* overlay | overlay dismisses on `onPlay` ✓ |
| User clicks ✕ | `onSeek` → `handleSeek` clears snapshot | same (already worked) ✓ |
| User navigates prev/next event | new snapshot shown | same (unchanged) ✓ |

## Test plan

- [ ] Navigate to an event with a snapshot — overlay appears
- [ ] Click Play — overlay dismisses immediately when video begins playing
- [ ] Click ✕ on the overlay — seeked to event ts, overlay gone
- [ ] Use prev/next event buttons — each shows its snapshot overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)