### PR TITLE
feat: seamless HLS playback — 24h VOD window + automatic window extension

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
 
     # Frigate VOD/HLS playback
     frigate_vod_enabled: bool = True
-    frigate_vod_window_sec: int = 7200  # width of HLS window to request from Frigate
+    frigate_vod_window_sec: int = 86400  # width of HLS window to request from Frigate (24 h)
 
     def ensure_dirs(self):
         """Create required directories if they don't exist."""

--- a/backend/app/services/hls.py
+++ b/backend/app/services/hls.py
@@ -27,7 +27,15 @@ def _build_hls_url(camera: str, requested_ts: float, seg_start: float) -> str:
 
     Pure function — no DB calls, no async, no side effects.
     Window starts 30s before requested_ts (or at seg_start, whichever is later)
-    and spans frigate_vod_window_sec seconds.
+    and spans frigate_vod_window_sec seconds (default 86400 = 24 h).
+
+    A 24-hour window is safe because Frigate's /api/vod/ endpoint stitches
+    existing MP4 segments on demand from the recordings filesystem — it does
+    not transcode or store a new file.  Requesting a larger window only changes
+    the playlist length; segments that have not yet been recorded are simply
+    absent from the manifest.  The frontend's hls.js instance therefore plays
+    everything available and can reload the source when it approaches the end
+    without the user ever seeing a stop.
     """
     window_start = max(seg_start, requested_ts - 30)
     window_end = window_start + settings.frigate_vod_window_sec

--- a/backend/tests/integration/test_playback_hls.py
+++ b/backend/tests/integration/test_playback_hls.py
@@ -129,3 +129,42 @@ async def test_segment_info_endpoint(client, test_app):
 async def test_segment_info_not_found(client):
     resp = await client.get("/api/segment/999999/info")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# HLS window is at least 86000 seconds wide (24-hour default)
+# ---------------------------------------------------------------------------
+
+async def test_hls_url_has_24h_window(client, test_app, monkeypatch):
+    from app import config
+    db_path = config.settings.database_path
+    start_ts = 1700400000.0
+    end_ts = start_ts + 20.0
+    _insert_segment(db_path, "window-cam", start_ts, end_ts)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.head = AsyncMock(return_value=mock_response)
+
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
+        resp = await client.get(
+            "/api/playback",
+            params={"camera": "window-cam", "ts": start_ts + 5.0},
+        )
+
+    assert resp.status_code == 200
+    hls_url = resp.json()["hls_url"]
+    assert hls_url is not None
+
+    # Parse /start/{s}/end/{e} from the URL and confirm window >= 86000s
+    import re
+    m = re.search(r"/start/(\d+)/end/(\d+)", hls_url)
+    assert m is not None, f"Could not parse start/end from HLS URL: {hls_url}"
+    window_sec = int(m.group(2)) - int(m.group(1))
+    assert window_sec >= 86000, (
+        f"Expected HLS window >= 86000s (24h), got {window_sec}s in URL: {hls_url}"
+    )

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -21,6 +21,7 @@
 import { useRef, useEffect, useState, useCallback } from 'react';
 import Hls from 'hls.js';
 import { formatTime } from '../utils/time.js';
+import { fetchPlaybackTarget } from '../utils/api.js';
 
 const LABEL_COLORS = {
   person: '#4CAF50',
@@ -29,6 +30,13 @@ const LABEL_COLORS = {
   cat: '#9C27B0',
   default: '#607D8B',
 };
+
+const WINDOW_EXTEND_THRESHOLD_SEC = 60;
+
+function _parseHlsWindowEnd(hlsUrl) {
+  const m = hlsUrl.match(/\/end\/(\d+)/);
+  return m ? parseFloat(m[1]) : null;
+}
 
 const HLS_CONFIG = {
   enableWorker: true,
@@ -56,6 +64,9 @@ export default function VideoPlayer({
   const hlsStartOffset = useRef(0);
   const isHlsActive = useRef(false);
   const loadingImgRef = useRef(null);
+  const hlsWindowEndTs = useRef(null);
+  const _hlsExtendingRef = useRef(false);
+  const _lastExtendTs = useRef(0);
 
   const [isPlaying, setIsPlaying] = useState(false);
   const [displayTime, setDisplayTime] = useState(null);
@@ -104,6 +115,75 @@ export default function VideoPlayer({
       hlsRef.current = null;
     }
     isHlsActive.current = false;
+    hlsWindowEndTs.current = null;
+    _hlsExtendingRef.current = false;
+  }
+
+  /** Load (or reload) an HLS source into the video element via hls.js or native HLS. */
+  function _loadHls(video, hlsUrl, seekOffset) {
+    hlsWindowEndTs.current = _parseHlsWindowEnd(hlsUrl);
+
+    if (Hls.isSupported()) {
+      _destroyHls();
+      setHlsMode(true);
+
+      const hls = new Hls(HLS_CONFIG);
+      hlsRef.current = hls;
+      isHlsActive.current = true;
+      // Re-parse after _destroyHls cleared it
+      hlsWindowEndTs.current = _parseHlsWindowEnd(hlsUrl);
+
+      hls.loadSource(hlsUrl);
+      hls.attachMedia(video);
+
+      hls.on(Hls.Events.MANIFEST_PARSED, () => {
+        if (seekOffset > 0) {
+          video.currentTime = seekOffset;
+        }
+        hlsStartOffset.current = video.currentTime;
+        video.play().catch(() => {});
+      });
+
+      hls.on(Hls.Events.ERROR, (_evt, data) => {
+        if (data.fatal) {
+          setError('HLS playback error — trying fallback');
+          _destroyHls();
+          setHlsMode(false);
+        }
+      });
+    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      // Native HLS path (Safari) — reload src in-place
+      video.src = hlsUrl;
+      video.load();
+      const onMeta = () => {
+        if (seekOffset > 0) {
+          video.currentTime = seekOffset;
+        }
+        hlsStartOffset.current = video.currentTime;
+        video.play().catch(() => {});
+      };
+      video.addEventListener('loadedmetadata', onMeta, { once: true });
+    }
+  }
+
+  /** Extend the HLS window to cover currentAbsoluteTs + 24h, preserving playback. */
+  async function _extendHlsWindow(currentAbsoluteTs) {
+    if (_hlsExtendingRef.current) return;
+    if (Math.abs(currentAbsoluteTs - _lastExtendTs.current) < 30) return;
+    _hlsExtendingRef.current = true;
+    _lastExtendTs.current = currentAbsoluteTs;
+    const video = videoRef.current;
+    if (!video) { _hlsExtendingRef.current = false; return; }
+    try {
+      const newTarget = await fetchPlaybackTarget(camera, currentAbsoluteTs);
+      if (newTarget?.hls_url) {
+        _loadHls(video, newTarget.hls_url, Math.min(newTarget.offset_sec, 30));
+      }
+    } catch (e) {
+      console.warn('HLS window extension failed:', e);
+    } finally {
+      _hlsExtendingRef.current = false;
+    }
   }
 
   /**
@@ -114,6 +194,8 @@ export default function VideoPlayer({
     if (!video || !playbackTarget) return;
 
     setError(null);
+    _hlsExtendingRef.current = false;
+    _lastExtendTs.current = 0;
 
     // ── Path 1 & 2: Frigate HLS VOD ──────────────────────────────────────────
     if (playbackTarget.hls_url) {
@@ -122,59 +204,9 @@ export default function VideoPlayer({
       // So: seekOffset = requested_ts - window_start = min(offset_sec, 30)
       const seekOffset = Math.min(playbackTarget.offset_sec, 30);
 
-      if (Hls.isSupported()) {
-        // hls.js path (Chrome, Firefox, Edge, …)
-        _destroyHls();
-        setHlsMode(true);
-
-        const hls = new Hls(HLS_CONFIG);
-        hlsRef.current = hls;
-        isHlsActive.current = true;
-
-        hls.loadSource(playbackTarget.hls_url);
-        hls.attachMedia(video);
-
-        hls.on(Hls.Events.MANIFEST_PARSED, () => {
-          if (seekOffset > 0) {
-            video.currentTime = seekOffset;
-          }
-          hlsStartOffset.current = video.currentTime;
-          video.play().catch(() => {});
-        });
-
-        hls.on(Hls.Events.ERROR, (_evt, data) => {
-          if (data.fatal) {
-            setError('HLS playback error — trying fallback');
-            _destroyHls();
-            setHlsMode(false);
-          }
-        });
-
+      if (Hls.isSupported() || video.canPlayType('application/vnd.apple.mpegurl')) {
+        _loadHls(video, playbackTarget.hls_url, seekOffset);
         return () => { _destroyHls(); };
-
-      } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
-        // Native HLS path (Safari)
-        _destroyHls();
-        setHlsMode(true);
-        isHlsActive.current = true;
-
-        video.src = playbackTarget.hls_url;
-        video.load();
-
-        const onMeta = () => {
-          if (seekOffset > 0) {
-            video.currentTime = seekOffset;
-          }
-          hlsStartOffset.current = video.currentTime;
-          video.play().catch(() => {});
-        };
-        video.addEventListener('loadedmetadata', onMeta, { once: true });
-
-        return () => {
-          video.removeEventListener('loadedmetadata', onMeta);
-          isHlsActive.current = false;
-          setHlsMode(false);
-        };
       }
     }
 
@@ -233,10 +265,21 @@ export default function VideoPlayer({
 
     setDisplayTime(absoluteTs);
     if (onTimeUpdate) onTimeUpdate(absoluteTs);
+
+    if (isHlsActive.current && hlsWindowEndTs.current && !_hlsExtendingRef.current) {
+      const secsUntilWindowEnd = hlsWindowEndTs.current - absoluteTs;
+      if (secsUntilWindowEnd > 0 && secsUntilWindowEnd < WINDOW_EXTEND_THRESHOLD_SEC) {
+        _extendHlsWindow(absoluteTs);
+      }
+    }
   }, [playbackTarget, onTimeUpdate]);
 
   const handleEnded = useCallback(() => {
     if (isHlsActive.current) {
+      if (displayTime && !_hlsExtendingRef.current) {
+        _extendHlsWindow(displayTime);
+        return;
+      }
       setIsPlaying(false);
       return;
     }


### PR DESCRIPTION
## Root cause

`_build_hls_url` in `hls.py` requested a 2-hour VOD window from Frigate's `/api/vod/` endpoint. When hls.js consumed all segments in that window it stopped, and the user had to press Play again to continue.

## Fix 1 — 24-hour VOD window (`config.py`, `hls.py`)

`frigate_vod_window_sec` default: **7200 → 86400**.

Frigate's `/api/vod/{camera}/start/{t}/end/{t}` endpoint stitches existing MP4 segments on demand from the recordings filesystem — it does not transcode or store a new file. Requesting a larger window only changes the playlist length; segments that haven't been recorded yet are simply absent from the manifest. There is no storage or CPU cost.

## Fix 2 — Automatic window extension (`VideoPlayer.jsx`)

Implements **v3 planned feature #1** from CLAUDE.md.

- `_loadHls(video, hlsUrl, seekOffset)` — new helper that centralises hls.js / native-HLS load logic (used by both the initial seek and each extension). Sets `hlsWindowEndTs.current` by parsing `/end/{ts}` from the URL.
- `_extendHlsWindow(absoluteTs)` — async function that fetches a fresh `PlaybackTarget` centred on the current position and calls `_loadHls` in-place. A 30s deadband (`_lastExtendTs`) and a boolean guard (`_hlsExtendingRef`) prevent concurrent fetches.
- `handleTimeUpdate` — triggers extension when `< 60s` remain in the current window.
- `handleEnded` (HLS branch) — triggers a last-chance extension before stopping playback.
- `_destroyHls()` — resets `hlsWindowEndTs`, `_hlsExtendingRef` so teardown is always clean.

**Architectural invariant preserved:** `_extendHlsWindow` never calls `onSeek` or modifies `cursorTs`. App.jsx has no knowledge that an extension occurred.

## Tests

`test_hls_url_has_24h_window` — parses `/start/{s}/end/{e}` from the returned HLS URL and asserts `e - s >= 86000`.

```
5 passed in 1.31s
```

## Test plan

- [ ] Seek to a point in the timeline and let HLS play — confirm it plays through without stopping at the 2h mark
- [ ] Open devtools Network tab — at ~60s before window end, a new `/api/playback` request fires and hls.js reloads the source without interrupting playback
- [ ] Seek to near the end of available recordings — player stops cleanly (no recordings left to extend into)
- [ ] Frigate unreachable scenario — extension fetch returns `hls_url: null`, player stops gracefully rather than crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)