### PR TITLE
fix(frontend): stale closure in health poll resets selected camera to alley east

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -189,8 +189,11 @@ export default function App() {
 
         setCameras(cams);
         setHealth(hp);
-        if (cams.length > 0 && !selectedCamera) {
-          setSelectedCamera(cams[0].name);
+        // TODO: when a frontend test harness is introduced, add a test that
+        // verifies the 30s health poll does NOT reset selectedCamera when one
+        // is already active. See CLAUDE.md "Example prompt" for context.
+        if (cams.length > 0) {
+          setSelectedCamera(prev => prev ?? cams[0].name);
         }
         setError(null);
       } catch (err) {


### PR DESCRIPTION
## Root cause

The 30-second health poll lives in a `useEffect(() => { ... }, [])`. The `init()` closure captured `selectedCamera = null` at mount time. Every poll cycle evaluated `!selectedCamera` against the stale null and called `setSelectedCamera(cams[0].name)`, unconditionally resetting the UI to alley east and interrupting playback and scrubbing on every other camera.

## Fix

```js
// Before — stale closure reads null every time
if (cams.length > 0 && !selectedCamera) {
  setSelectedCamera(cams[0].name);
}

// After — functional updater reads current state at call time
if (cams.length > 0) {
  setSelectedCamera(prev => prev ?? cams[0].name);
}
```

`prev ?? cams[0].name` returns `prev` unchanged if a camera is already selected; sets the first camera only on first load when `prev` is still null. The dependency array stays `[]` — adding `selectedCamera` would restart the interval on every camera change.

## Test plan

- [ ] Select a non-first camera (e.g. back yard), start playback, wait 30 seconds — confirm camera does not reset to alley east
- [ ] On first load with no camera selected, confirm first camera is auto-selected as before
- [ ] TODO comment added near fix for future RTL test coverage

## Frontend-only change

No backend impact. No existing frontend test harness to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)