### PR TITLE
fix(frontend): handleSegmentAdvance closure causes VideoPlayer to re-render on every timeupdate

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -10,7 +10,7 @@
  *   - SplitView path unchanged
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 
 function useIsMobile(breakpoint = 768) {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < breakpoint);
@@ -178,6 +178,14 @@ export default function App() {
   // Event snapshot state (from prev/next navigation)
   const [activeEventSnapshot, setActiveEventSnapshot] = useState(null);
 
+  // Refs that track the latest cursorTs / playbackTarget without being deps
+  // of handleSegmentAdvance — avoids recreating the callback (and therefore
+  // VideoPlayer's onSegmentAdvance prop) on every timeupdate event.
+  const cursorTsRef = useRef(null);
+  const playbackTargetRef = useRef(null);
+  useEffect(() => { cursorTsRef.current = cursorTs; }, [cursorTs]);
+  useEffect(() => { playbackTargetRef.current = playbackTarget; }, [playbackTarget]);
+
   // ─── Init: load cameras + health ───
   useEffect(() => {
     let cancelled = false;
@@ -288,21 +296,28 @@ export default function App() {
   );
 
   // ─── Segment advance: fixes cursor drift bug ───
+  // TODO: add test verifying onSegmentAdvance prop is stable across
+  // cursorTs updates (does not change reference on timeupdate events)
   const handleSegmentAdvance = useCallback(
     async (nextSegmentId) => {
       if (!selectedCamera) return;
       try {
-        const nextTs = playbackTarget?.segment_end_ts ?? (cursorTs ?? 0);
+        const nextTs = playbackTargetRef.current?.segment_end_ts ?? (cursorTsRef.current ?? 0);
         const target = await fetchPlaybackTarget(selectedCamera, nextTs + 0.1);
         setPlaybackTarget(target);
       } catch {}
     },
-    [selectedCamera, playbackTarget, cursorTs]
+    [selectedCamera]   // no longer depends on cursorTs or playbackTarget
   );
 
   // ─── Playback time tracking ───
   const handlePlaybackTimeUpdate = useCallback((absoluteTs) => {
     setCursorTs(absoluteTs);
+  }, []);
+
+  // ─── Playback start: dismiss event snapshot overlay ───
+  const handlePlaybackStart = useCallback(() => {
+    setActiveEventSnapshot(null);
   }, []);
 
   // ─── Camera switch ───
@@ -688,7 +703,7 @@ export default function App() {
                 isMobile={isMobile}
                 eventSnapshot={activeEventSnapshot}
                 onSeek={handleSeek}
-                onPlaybackStart={() => setActiveEventSnapshot(null)}
+                onPlaybackStart={handlePlaybackStart}
               />
             </div>
 


### PR DESCRIPTION
## Root cause

`handleSegmentAdvance` listed `cursorTs` and `playbackTarget` in its `useCallback` dep array. Both change constantly during playback:
- `cursorTs` via `handlePlaybackTimeUpdate` → ~4–10 times/sec on every `timeupdate` event
- `playbackTarget` on each segment transition

This created a cascade:
1. `handleSegmentAdvance` → new reference multiple times/sec
2. `VideoPlayer` receives new `onSegmentAdvance` prop → re-renders multiple times/sec
3. `handleEnded` (which deps on `onSegmentAdvance`) → recreated → `video.onended` replaced repeatedly during active playback

`onPlaybackStart` had the same problem as an inline arrow `() => setActiveEventSnapshot(null)` — new reference on every App render.

## Fix

**Fix 1 — `handleSegmentAdvance`:** Replace closure capture with refs that track current values without being deps:

```js
const cursorTsRef = useRef(null);
const playbackTargetRef = useRef(null);
useEffect(() => { cursorTsRef.current = cursorTs; }, [cursorTs]);
useEffect(() => { playbackTargetRef.current = playbackTarget; }, [playbackTarget]);

const handleSegmentAdvance = useCallback(async (nextSegmentId) => {
  if (!selectedCamera) return;
  try {
    const nextTs = playbackTargetRef.current?.segment_end_ts ?? (cursorTsRef.current ?? 0);
    const target = await fetchPlaybackTarget(selectedCamera, nextTs + 0.1);
    setPlaybackTarget(target);
  } catch {}
}, [selectedCamera]);  // ← no longer depends on cursorTs or playbackTarget
```

**Fix 2 — `onPlaybackStart`:** Extract inline arrow to a stable `useCallback([], [])`:

```js
const handlePlaybackStart = useCallback(() => {
  setActiveEventSnapshot(null);
}, []);
```

## Frontend-only change

No backend impact. No existing frontend test harness. TODO comment added for future stability test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)