### PR TITLE
refactor(frontend): fixed-reticle interaction model with keyboard navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,12 @@ import {
 } from './utils/api.js';
 import { nowTs, formatDateTime, formatTime } from './utils/time.js';
 
+// Reticle sits at the upper third of the VerticalTimeline viewport.
+// RETICLE_FRACTION of the range is "future" (above reticle);
+// (1 - RETICLE_FRACTION) is "past" (below reticle).
+// Exported so VerticalTimeline can use the same value for rendering.
+export const RETICLE_FRACTION = 1 / 3;
+
 const MIN_RANGE_SEC = 15 * 60;
 const MAX_RANGE_SEC = 7 * 24 * 3600;
 
@@ -140,28 +146,25 @@ export default function App() {
 
   const [timelineData, setTimelineData] = useState(null);
   const [previewFrames, setPreviewFrames] = useState([]);
-  const [cursorTs, setCursorTs] = useState(() => nowTs() - 12 * 3600);
-  const [rangeSec, setRangeSec] = useState(24 * 3600);
+  const [cursorTs, setCursorTs] = useState(() => nowTs());
+  const [rangeSec, setRangeSec] = useState(8 * 3600);
   const [hoverTs, setHoverTs] = useState(null);
   const [playbackTarget, setPlaybackTarget] = useState(null);
   const [health, setHealth] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // ── Derived range: cursorTs is always at vertical center ───────────────────
-  // TODO: add test verifying rangeEnd never exceeds nowTs() when cursorTs is near now
+  // ── Derived range: reticle at RETICLE_FRACTION from top ────────────────────
+  // cursorTs maps to the reticle position by construction:
+  //   rangeStart = cursorTs - rangeSec * (1 - RETICLE_FRACTION)  [past below reticle]
+  //   rangeEnd   = cursorTs + rangeSec * RETICLE_FRACTION         [future above reticle]
+  // TODO: verify rangeEnd never exceeds nowTs() + 60, rangeStart = cursorTs - rangeSec * (1 - RETICLE_FRACTION)
   // TODO: during video playback, cursorTs updates at ~30Hz; each update drives a
   //   rangeStart/rangeEnd change that triggers the data-fetch useEffect — consider
   //   debouncing in a follow-up PR if this causes excessive backend requests
   const { rangeStart, rangeEnd } = useMemo(() => {
-    const halfRange = rangeSec / 2;
-    const now = nowTs();
-    let start = cursorTs - halfRange;
-    let end = cursorTs + halfRange;
-    if (end > now) {
-      end = now;
-      start = now - rangeSec;
-    }
+    const start = cursorTs - rangeSec * (1 - RETICLE_FRACTION);
+    const end = Math.min(cursorTs + rangeSec * RETICLE_FRACTION, nowTs() + 60);
     return { rangeStart: start, rangeEnd: end };
   }, [cursorTs, rangeSec]);
 
@@ -169,7 +172,8 @@ export default function App() {
 
   // Keyboard navigation + Escape to close ops drawer
   // Shortcuts: ← / → = ±5s | Shift+← / → = ±30s | Cmd/Ctrl+← / → = ±5m
-  // TODO: add React Testing Library tests for keyboard navigation when frontend test harness is introduced
+  // TODO: test with React Testing Library — verify arrow keys adjust cursorTs,
+  //       skip when input focused, clamp at nowTs()
   useEffect(() => {
     const handler = (e) => {
       if (e.key === 'Escape') { setOpsOpen(false); return; }
@@ -185,15 +189,11 @@ export default function App() {
       if (e.key === 'ArrowLeft') delta = -delta;
       e.preventDefault();
 
-      setCursorTs(prev => {
-        const next = prev + delta;
-        const maxCursor = nowTs() - rangeSec / 2;
-        return Math.min(next, maxCursor);
-      });
+      setCursorTs(prev => Math.min(prev + delta, nowTs()));
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [rangeSec]);
+  }, []);
 
   // Mobile header expand/collapse
   const [healthExpanded, setHealthExpanded] = useState(false);
@@ -311,14 +311,10 @@ export default function App() {
     setHoverTs(null);
   }, []);
 
-  // ─── Pan: shift cursorTs by deltaSec, clamping so rangeEnd ≤ now ───
+  // ─── Pan: shift cursorTs by deltaSec, clamping at nowTs() ───
   const handlePan = useCallback((deltaSec) => {
-    setCursorTs(prev => {
-      const next = prev + deltaSec;
-      const maxCursor = nowTs() - rangeSec / 2;
-      return Math.min(next, maxCursor);
-    });
-  }, [rangeSec]);
+    setCursorTs(prev => Math.min(prev + deltaSec, nowTs()));
+  }, []);
 
   // ─── Zoom: change visible window width, keeping cursorTs fixed ───
   const handleZoomChange = useCallback((newRangeSec) => {
@@ -400,20 +396,19 @@ export default function App() {
     }
   }, [multiMode]);
 
-  // ─── Range presets ───
+  // ─── Range presets: snap cursorTs to now so reticle shows current time ───
   const setRange = useCallback((hours) => {
-    const newRangeSec = hours * 3600;
-    const now = nowTs();
-    setRangeSec(newRangeSec);
-    setCursorTs(now - newRangeSec / 2);
+    setRangeSec(hours * 3600);
+    setCursorTs(nowTs());
   }, []);
 
-  // ─── "Go to" handler ───
+  // ─── "Go to" handler: recenter view on ts, rangeSec unchanged ───
   const handleGoto = useCallback(() => {
     if (!gotoValue) return;
     const ts = new Date(gotoValue).getTime() / 1000;
     if (isNaN(ts)) return;
     setCursorTs(ts);
+    // Also load playback at the target ts
     handleSeek(ts);
   }, [gotoValue, handleSeek]);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,7 @@ import {
   requestPreviews,
   eventSnapshotUrl,
 } from './utils/api.js';
-import { todayStartTs, nowTs, formatDateTime, formatTime } from './utils/time.js';
+import { nowTs, formatDateTime, formatTime } from './utils/time.js';
 
 const MIN_RANGE_SEC = 15 * 60;
 const MAX_RANGE_SEC = 7 * 24 * 3600;
@@ -140,24 +140,60 @@ export default function App() {
 
   const [timelineData, setTimelineData] = useState(null);
   const [previewFrames, setPreviewFrames] = useState([]);
-  const [cursorTs, setCursorTs] = useState(null);
+  const [cursorTs, setCursorTs] = useState(() => nowTs() - 12 * 3600);
+  const [rangeSec, setRangeSec] = useState(24 * 3600);
   const [hoverTs, setHoverTs] = useState(null);
   const [playbackTarget, setPlaybackTarget] = useState(null);
   const [health, setHealth] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  const [rangeStart, setRangeStart] = useState(todayStartTs());
-  const [rangeEnd, setRangeEnd] = useState(nowTs());
+  // ── Derived range: cursorTs is always at vertical center ───────────────────
+  // TODO: add test verifying rangeEnd never exceeds nowTs() when cursorTs is near now
+  // TODO: during video playback, cursorTs updates at ~30Hz; each update drives a
+  //   rangeStart/rangeEnd change that triggers the data-fetch useEffect — consider
+  //   debouncing in a follow-up PR if this causes excessive backend requests
+  const { rangeStart, rangeEnd } = useMemo(() => {
+    const halfRange = rangeSec / 2;
+    const now = nowTs();
+    let start = cursorTs - halfRange;
+    let end = cursorTs + halfRange;
+    if (end > now) {
+      end = now;
+      start = now - rangeSec;
+    }
+    return { rangeStart: start, rangeEnd: end };
+  }, [cursorTs, rangeSec]);
 
   const [gotoValue, setGotoValue] = useState(() => toDatetimeLocal(nowTs()));
 
-  // Escape key closes ops drawer
+  // Keyboard navigation + Escape to close ops drawer
+  // Shortcuts: ← / → = ±5s | Shift+← / → = ±30s | Cmd/Ctrl+← / → = ±5m
+  // TODO: add React Testing Library tests for keyboard navigation when frontend test harness is introduced
   useEffect(() => {
-    const handler = (e) => { if (e.key === 'Escape') setOpsOpen(false); };
+    const handler = (e) => {
+      if (e.key === 'Escape') { setOpsOpen(false); return; }
+      const tag = e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+
+      let delta;
+      if (e.metaKey || e.ctrlKey) delta = 5 * 60;
+      else if (e.shiftKey) delta = 30;
+      else delta = 5;
+
+      if (e.key === 'ArrowLeft') delta = -delta;
+      e.preventDefault();
+
+      setCursorTs(prev => {
+        const next = prev + delta;
+        const maxCursor = nowTs() - rangeSec / 2;
+        return Math.min(next, maxCursor);
+      });
+    };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, []);
+  }, [rangeSec]);
 
   // Mobile header expand/collapse
   const [healthExpanded, setHealthExpanded] = useState(false);
@@ -255,25 +291,39 @@ export default function App() {
     return timelineData.events.filter(e => activeLabels.has(e.label));
   }, [timelineData, activeLabels]);
 
-  // ─── Range change (from zoom or presets) ───
+  // ─── Range change — kept for SplitView backward compat ───
   const handleRangeChange = useCallback((newStart, newEnd) => {
     const newRange = newEnd - newStart;
     if (newRange < MIN_RANGE_SEC || newRange > MAX_RANGE_SEC) return;
-    setRangeStart(newStart);
-    setRangeEnd(newEnd);
+    setRangeSec(newRange);
+    setCursorTs(newStart + newRange / 2);
   }, []);
 
-  // ─── Scrub handler: sets hover position + moves cursor line ───
-  // Snaps to nearest covered segment so preview and cursor never land in a gap.
+  // ─── Scrub handler: sets hover position for preview overlay ───
+  // cursorTs is NOT updated on hover — only clicking (handleSeek) recenters the view.
   const handleScrub = useCallback((ts) => {
     const snapped = snapToCoverage(ts, timelineData?.segments);
     setHoverTs(snapped);
-    setCursorTs(snapped);
   }, [timelineData]);
 
-  // ─── Scrub end: clear hover (cursor stays at last position) ───
+  // ─── Scrub end: clear hover ───
   const handleScrubEnd = useCallback(() => {
     setHoverTs(null);
+  }, []);
+
+  // ─── Pan: shift cursorTs by deltaSec, clamping so rangeEnd ≤ now ───
+  const handlePan = useCallback((deltaSec) => {
+    setCursorTs(prev => {
+      const next = prev + deltaSec;
+      const maxCursor = nowTs() - rangeSec / 2;
+      return Math.min(next, maxCursor);
+    });
+  }, [rangeSec]);
+
+  // ─── Zoom: change visible window width, keeping cursorTs fixed ───
+  const handleZoomChange = useCallback((newRangeSec) => {
+    if (newRangeSec < MIN_RANGE_SEC || newRangeSec > MAX_RANGE_SEC) return;
+    setRangeSec(newRangeSec);
   }, []);
 
   // ─── Seek handler: commits playback, clears hover + snapshot ───
@@ -286,6 +336,7 @@ export default function App() {
 
       try {
         const target = await fetchPlaybackTarget(selectedCamera, ts);
+        console.log('[APP] setPlaybackTarget from timeline click/seek', target);
         setPlaybackTarget(target);
         setError(null);
       } catch (err) {
@@ -304,6 +355,7 @@ export default function App() {
       try {
         const nextTs = playbackTargetRef.current?.segment_end_ts ?? (cursorTsRef.current ?? 0);
         const target = await fetchPlaybackTarget(selectedCamera, nextTs + 0.1);
+        console.log('[APP] setPlaybackTarget from auto-advance', target);
         setPlaybackTarget(target);
       } catch {}
     },
@@ -350,9 +402,10 @@ export default function App() {
 
   // ─── Range presets ───
   const setRange = useCallback((hours) => {
-    const end = nowTs();
-    setRangeStart(end - hours * 3600);
-    setRangeEnd(end);
+    const newRangeSec = hours * 3600;
+    const now = nowTs();
+    setRangeSec(newRangeSec);
+    setCursorTs(now - newRangeSec / 2);
   }, []);
 
   // ─── "Go to" handler ───
@@ -360,10 +413,9 @@ export default function App() {
     if (!gotoValue) return;
     const ts = new Date(gotoValue).getTime() / 1000;
     if (isNaN(ts)) return;
-    const halfRange = (rangeEnd - rangeStart) / 2;
-    handleRangeChange(ts - halfRange, ts + halfRange);
+    setCursorTs(ts);
     handleSeek(ts);
-  }, [gotoValue, rangeStart, rangeEnd, handleRangeChange, handleSeek]);
+  }, [gotoValue, handleSeek]);
 
   // ─── Label filter handlers ───
   const toggleLabel = useCallback((label) => {
@@ -402,6 +454,7 @@ export default function App() {
     setCursorTs(target.start_ts);
     try {
       const playTarget = await fetchPlaybackTarget(selectedCamera, target.start_ts);
+      console.log('[APP] setPlaybackTarget from event navigation', playTarget);
       setPlaybackTarget(playTarget);
     } catch {}
 
@@ -416,12 +469,8 @@ export default function App() {
       setActiveEventSnapshot(null);
     }
 
-    // Re-center range if event is outside current view
-    if (target.start_ts < rangeStart || target.start_ts > rangeEnd) {
-      const halfRange = (rangeEnd - rangeStart) / 2;
-      handleRangeChange(target.start_ts - halfRange, target.start_ts + halfRange);
-    }
-  }, [filteredEvents, cursorTs, selectedCamera, rangeStart, rangeEnd, handleRangeChange]);
+    // setCursorTs(target.start_ts) above recenters the derived range automatically
+  }, [filteredEvents, cursorTs, selectedCamera]);
 
   // ─── Derive scrub preview URL ───
   const activePreviewUrl =
@@ -751,7 +800,8 @@ export default function App() {
                 onScrub={handleScrub}
                 onScrubEnd={handleScrubEnd}
                 onSeek={handleSeek}
-                onRangeChange={handleRangeChange}
+                onPan={handlePan}
+                onZoomChange={handleZoomChange}
                 isMobile={isMobile}
                 onPreviewRequest={(ts) => {
                   const halfWindow = 5 * 60;

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -19,14 +19,22 @@
  *   7.  Time tick labels + horizontal hairlines across bar zone
  *   8.  Event markers (right strip)
  *   9.  Hover line (yellow, mouse position)
- *   10. Playback cursor (red, cursorTs) + timestamp badge
+ *   10. Reticle: glow band + two thin lines + timestamp badge
  *
- * Scroll: pans the time window forward/backward (15% per tick).
- * Zoom: controlled by −/slider/+ strip below the canvas.
+ * Interaction model (fixed-reticle / radar):
+ *   - Reticle is physically fixed at h * RETICLE_FRACTION from top.
+ *   - Scroll = pan: timeline flows under the reticle (onPan callback).
+ *   - Click = recenter: clicked ts moves to reticle with 250ms ease-out animation.
+ *   - Zoom: −/slider/+ strip calls onZoomChange with a new rangeSec value.
+ *
+ * Animation invariant: the 250ms cursor interpolation uses refs + rAF exclusively
+ * — no setState per frame. Canvas reads from displayCursorRef when animation
+ * is active, falling back to the cursorTs prop when idle.
  */
 
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { formatTimeShort, clampTs, nowTs } from '../utils/time.js';
+import { RETICLE_FRACTION } from '../App.jsx';
 
 function useDebounce(fn, delay) {
   const timer = useRef(null);
@@ -63,12 +71,16 @@ const ZOOM_STOP_LABELS = [
   '1h', '2h', '4h', '8h', '12h', '18h', '24h', '48h', '7d',
 ];
 
-/** Zoom-aware pan fraction: slower at fine zoom, faster at wide zoom. */
-function panFraction(rangeSec) {
-  if (rangeSec <= 1800)  return 0.05;  // ≤30m → precise (5%)
-  if (rangeSec <= 3600)  return 0.08;  // ≤1h  → precise
-  if (rangeSec <= 28800) return 0.12;  // ≤8h  → medium
-  return 0.18;                          // >8h  → fast
+/**
+ * Zoom-aware base pan amount in seconds per scroll tick.
+ * Slower at fine zoom (precise positioning), faster at wide zoom (quick navigation).
+ * TODO: unit test velocity calculation — verify multiplier caps at 4x, window prunes correctly
+ */
+function panAmountSec(rangeSec) {
+  if (rangeSec <= 1800)  return rangeSec * 0.03;  // ≤30m → 3%
+  if (rangeSec <= 3600)  return rangeSec * 0.05;  // ≤1h  → 5%
+  if (rangeSec <= 28800) return rangeSec * 0.08;  // ≤8h  → 8%
+  return rangeSec * 0.12;                          // >8h  → 12%
 }
 
 const EVENT_COLORS = {
@@ -130,6 +142,12 @@ export default function VerticalTimeline({
   const touchStartRef = useRef(null);
   const scrollTimestamps = useRef([]);
 
+  // Animation refs — no state to avoid per-frame re-renders
+  // TODO: verify animation ref doesn't leak — must cancel on unmount and on new click during active animation
+  const displayCursorRef = useRef(cursorTs);  // what the canvas currently displays
+  const animRef = useRef(null);               // { from, to, startTime, rafId } | null
+  const drawCanvasRef = useRef(null);         // always points to latest draw fn
+
   const [dims, setDims] = useState({ w: 215, h: 600 });
   const [hoverY, setHoverY] = useState(null);
 
@@ -167,8 +185,12 @@ export default function VerticalTimeline({
     return () => obs.disconnect();
   }, []);
 
-  // ── Canvas render ───────────────────────────────────────────────────────────
-  useEffect(() => {
+  // ── Canvas draw function ────────────────────────────────────────────────────
+  // Extracted as useCallback so it can be called both from the data-change
+  // useEffect and imperatively from the animation rAF loop.
+  // Reads displayCursorRef.current for cursor position — never from the prop
+  // directly, so animation interpolation is reflected without setState.
+  const drawCanvas = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
 
@@ -363,41 +385,76 @@ export default function VerticalTimeline({
       ctx.stroke();
     }
 
-    // 10. Playback cursor (red) fixed at vertical center + timestamp badge
-    if (cursorTs != null) {
-      const cy = h / 2; // cursor is always at center — timeline scrolls under it
+    // 10. Reticle at fixed Y = h * RETICLE_FRACTION
+    // The reticle Y is a constant — it never moves. cursorTs always maps here
+    // by construction (rangeStart/rangeEnd are derived from cursorTs in App.jsx).
+    const displayTs = displayCursorRef.current;
+    if (displayTs != null) {
+      const reticleY = h * RETICLE_FRACTION;
 
-      ctx.strokeStyle = '#ff4444';
-      ctx.lineWidth = 4;
+      // Subtle glow band (40px tall, centered on reticleY)
+      ctx.fillStyle = 'rgba(60, 160, 220, 0.06)';
+      ctx.fillRect(barStart, reticleY - 20, barW, 40);
+
+      // Two thin horizontal lines with a 20px gap between them
+      ctx.strokeStyle = 'rgba(100, 180, 220, 0.6)';
+      ctx.lineWidth = 1;
       ctx.beginPath();
-      ctx.moveTo(barStart, cy);
-      ctx.lineTo(barEnd, cy);
+      ctx.moveTo(barStart, reticleY - 10);
+      ctx.lineTo(barEnd, reticleY - 10);
+      ctx.moveTo(barStart, reticleY + 10);
+      ctx.lineTo(barEnd, reticleY + 10);
       ctx.stroke();
 
-      const label = formatTimeShort(cursorTs);
-      ctx.font = 'bold 15px monospace';
-      ctx.textAlign = 'left';
-      ctx.textBaseline = 'top';
+      // Timestamp badge centered in the gap
+      const label = formatTimeShort(displayTs);
+      ctx.font = 'bold 14px monospace';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
       const textW = ctx.measureText(label).width;
-      const badgePad = 3;
-      const badgeX = barStart + 4;
-      const badgeY = Math.max(cy - 21, 0);
+      const badgePad = 4;
+      const badgeCx = barStart + barW / 2;
+      const badgeX = badgeCx - textW / 2 - badgePad;
 
-      ctx.fillStyle = 'rgba(20,10,10,0.85)';
-      ctx.strokeStyle = '#ff4444';
-      ctx.lineWidth = 1.5;
+      ctx.fillStyle = 'rgba(10, 20, 35, 0.88)';
+      ctx.strokeStyle = 'rgba(100, 180, 220, 0.5)';
+      ctx.lineWidth = 1;
       ctx.beginPath();
-      ctx.rect(badgeX - badgePad, badgeY, textW + badgePad * 2, 19);
+      ctx.rect(badgeX, reticleY - 9, textW + badgePad * 2, 18);
       ctx.fill();
       ctx.stroke();
 
-      ctx.fillStyle = '#ff8888';
-      ctx.fillText(label, badgeX, badgeY + 3);
+      ctx.fillStyle = 'rgba(160, 210, 240, 0.95)';
+      ctx.fillText(label, badgeCx, reticleY);
     }
-  }, [dims, startTs, endTs, range, segments, gaps, events, activity, cursorTs, hoverY, tsToY]);
+  }, [dims, startTs, endTs, range, segments, gaps, events, activity, hoverY, tsToY]);
+  // Note: cursorTs is NOT a dep — read from displayCursorRef at draw time.
+
+  // Keep drawCanvasRef pointing to the latest version of drawCanvas.
+  // The rAF animation loop calls drawCanvasRef.current() so it always uses
+  // current props even if the component re-rendered mid-animation.
+  useEffect(() => { drawCanvasRef.current = drawCanvas; }, [drawCanvas]);
+
+  // Trigger canvas redraw whenever draw deps change (data, layout, hover).
+  useEffect(() => { drawCanvas(); }, [drawCanvas]);
+
+  // Sync displayCursorRef from cursorTs prop when no animation is running,
+  // then immediately redraw so cursor position stays current during playback.
+  useEffect(() => {
+    if (!animRef.current) {
+      displayCursorRef.current = cursorTs;
+      drawCanvasRef.current?.();
+    }
+  }, [cursorTs]);
+
+  // Cancel any in-flight animation on unmount.
+  useEffect(() => {
+    return () => {
+      if (animRef.current?.rafId) cancelAnimationFrame(animRef.current.rafId);
+    };
+  }, []);
 
   // ── Scroll-to-pan: zoom-aware sensitivity + velocity acceleration ────────────
-  // TODO: add unit tests for velocity calculation when frontend test harness is introduced
   const handleWheel = useCallback(
     (e) => {
       if (!onPan) return;
@@ -408,14 +465,15 @@ export default function VerticalTimeline({
       scrollTimestamps.current = scrollTimestamps.current.filter(t => now - t < 200);
       scrollTimestamps.current.push(now);
 
-      const velocityFactor = scrollTimestamps.current.length / 3;
-      const fraction = panFraction(range);
-      const baseDelta = range * fraction;
-      const effectiveDelta = baseDelta * (1 + Math.min(velocityFactor, 3));
+      const count = scrollTimestamps.current.length;
+      let delta = panAmountSec(range);
+      // Velocity acceleration: >2 events in window → multiply, capped at 4×
+      if (count > 2) {
+        delta *= Math.min(count / 2, 4);
+      }
 
-      // deltaY < 0 = scroll up = go backward in time
-      const delta = e.deltaY < 0 ? -effectiveDelta : effectiveDelta;
-      onPan(delta);
+      // deltaY < 0 = scroll up = go backward in time (earlier timestamps)
+      onPan(e.deltaY < 0 ? -delta : delta);
     },
     [range, onPan]
   );
@@ -467,12 +525,45 @@ export default function VerticalTimeline({
     [getTs, onScrub, debouncedPreviewRequest]
   );
 
+  // Click = recenter with 250ms ease-out animation.
+  // Animation uses refs + rAF — no setState per frame.
+  // The animation starts from the current displayCursorRef value (which may
+  // itself be mid-animation if user clicks again before it finishes).
   const handleMouseUp = useCallback(
     (e) => {
       if (!isDragging.current) return;
       isDragging.current = false;
+
       const ts = getTs(e);
-      if (ts != null && onSeek) onSeek(ts);
+      if (ts == null) return;
+
+      const from = displayCursorRef.current ?? ts;
+      const startTime = performance.now();
+      const DURATION_MS = 250;
+
+      // Cancel any in-flight animation
+      if (animRef.current?.rafId) cancelAnimationFrame(animRef.current.rafId);
+
+      function tick(now) {
+        const elapsed = now - startTime;
+        const t = Math.min(elapsed / DURATION_MS, 1);
+        // Ease-out cubic: fast start, decelerates to rest
+        const eased = 1 - (1 - t) ** 3;
+        displayCursorRef.current = from + (ts - from) * eased;
+        drawCanvasRef.current?.();
+
+        if (t < 1) {
+          animRef.current.rafId = requestAnimationFrame(tick);
+        } else {
+          displayCursorRef.current = ts;
+          animRef.current = null;
+        }
+      }
+
+      animRef.current = { from, to: ts, startTime, rafId: requestAnimationFrame(tick) };
+
+      // Notify App.jsx — sets cursorTs which recomputes rangeStart/rangeEnd
+      if (onSeek) onSeek(ts);
     },
     [getTs, onSeek]
   );
@@ -517,9 +608,9 @@ export default function VerticalTimeline({
           const isHorizontalSwipe = Math.abs(dx) > Math.abs(dy) * 1.5 && Math.abs(dx) > 10;
 
           if (isHorizontalSwipe && onPan) {
+            // Horizontal swipe → pan: map swipe distance to time delta
             const fraction = -dx / dims.w * 0.5;
-            const panAmount = range * fraction;
-            onPan(panAmount);
+            onPan(range * fraction);
             touchStartRef.current = { x: touch.clientX, y: touch.clientY };
             return;
           }

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -63,8 +63,13 @@ const ZOOM_STOP_LABELS = [
   '1h', '2h', '4h', '8h', '12h', '18h', '24h', '48h', '7d',
 ];
 
-const PAN_FRACTION = 0.15; // 15% of range per scroll tick
-const MIN_RANGE_SEC = 15 * 60;
+/** Zoom-aware pan fraction: slower at fine zoom, faster at wide zoom. */
+function panFraction(rangeSec) {
+  if (rangeSec <= 1800)  return 0.05;  // ≤30m → precise (5%)
+  if (rangeSec <= 3600)  return 0.08;  // ≤1h  → precise
+  if (rangeSec <= 28800) return 0.12;  // ≤8h  → medium
+  return 0.18;                          // >8h  → fast
+}
 
 const EVENT_COLORS = {
   person: '#4CAF50',
@@ -114,7 +119,8 @@ export default function VerticalTimeline({
   onScrub,
   onScrubEnd,
   onSeek,
-  onRangeChange,
+  onPan,
+  onZoomChange,
   onPreviewRequest = null,
   isMobile = false,
 }) {
@@ -122,6 +128,7 @@ export default function VerticalTimeline({
   const containerRef = useRef(null);
   const isDragging = useRef(false);
   const touchStartRef = useRef(null);
+  const scrollTimestamps = useRef([]);
 
   const [dims, setDims] = useState({ w: 215, h: 600 });
   const [hoverY, setHoverY] = useState(null);
@@ -356,9 +363,9 @@ export default function VerticalTimeline({
       ctx.stroke();
     }
 
-    // 10. Playback cursor (red) + floating timestamp badge
+    // 10. Playback cursor (red) fixed at vertical center + timestamp badge
     if (cursorTs != null) {
-      const cy = tsToY(cursorTs);
+      const cy = h / 2; // cursor is always at center — timeline scrolls under it
 
       ctx.strokeStyle = '#ff4444';
       ctx.lineWidth = 4;
@@ -389,29 +396,28 @@ export default function VerticalTimeline({
     }
   }, [dims, startTs, endTs, range, segments, gaps, events, activity, cursorTs, hoverY, tsToY]);
 
-  // ── Scroll-to-pan ───────────────────────────────────────────────────────────
+  // ── Scroll-to-pan: zoom-aware sensitivity + velocity acceleration ────────────
+  // TODO: add unit tests for velocity calculation when frontend test harness is introduced
   const handleWheel = useCallback(
     (e) => {
-      if (!onRangeChange) return;
+      if (!onPan) return;
       e.preventDefault();
 
-      const panAmount = range * PAN_FRACTION;
-      // deltaY < 0 = scroll up = go backward in time (negative delta)
-      const delta = e.deltaY < 0 ? -panAmount : panAmount;
+      const now = Date.now();
+      // Keep only timestamps within the 200ms velocity window
+      scrollTimestamps.current = scrollTimestamps.current.filter(t => now - t < 200);
+      scrollTimestamps.current.push(now);
 
-      const now = nowTs();
-      let newStart = startTs + delta;
-      let newEnd = endTs + delta;
+      const velocityFactor = scrollTimestamps.current.length / 3;
+      const fraction = panFraction(range);
+      const baseDelta = range * fraction;
+      const effectiveDelta = baseDelta * (1 + Math.min(velocityFactor, 3));
 
-      // Clamp: don't scroll past "now"
-      if (newEnd > now) {
-        newEnd = now;
-        newStart = now - range;
-      }
-
-      onRangeChange(newStart, newEnd);
+      // deltaY < 0 = scroll up = go backward in time
+      const delta = e.deltaY < 0 ? -effectiveDelta : effectiveDelta;
+      onPan(delta);
     },
-    [startTs, endTs, range, onRangeChange]
+    [range, onPan]
   );
 
   useEffect(() => {
@@ -421,31 +427,13 @@ export default function VerticalTimeline({
     return () => canvas.removeEventListener('wheel', handleWheel);
   }, [handleWheel]);
 
-  // ── Zoom: apply a stop index, centering on cursorTs or midpoint ─────────────
+  // ── Zoom: apply a stop index; App.jsx keeps cursorTs fixed while range changes ─
   const applyZoom = useCallback(
     (idx) => {
       const clamped = Math.max(0, Math.min(ZOOM_STOPS.length - 1, idx));
-      const newRange = ZOOM_STOPS[clamped];
-
-      // Center on cursor if it's within view, otherwise on midpoint
-      const mid = (startTs + endTs) / 2;
-      const center =
-        cursorTs != null && cursorTs >= startTs && cursorTs <= endTs
-          ? cursorTs
-          : mid;
-
-      const now = nowTs();
-      let newStart = center - newRange / 2;
-      let newEnd = center + newRange / 2;
-
-      if (newEnd > now) {
-        newEnd = now;
-        newStart = now - newRange;
-      }
-
-      if (onRangeChange) onRangeChange(newStart, newEnd);
+      if (onZoomChange) onZoomChange(ZOOM_STOPS[clamped]);
     },
-    [startTs, endTs, cursorTs, onRangeChange]
+    [onZoomChange]
   );
 
   // ── Mouse handlers ──────────────────────────────────────────────────────────
@@ -528,15 +516,10 @@ export default function VerticalTimeline({
           const dy = touch.clientY - (touchStartRef.current?.y ?? touch.clientY);
           const isHorizontalSwipe = Math.abs(dx) > Math.abs(dy) * 1.5 && Math.abs(dx) > 10;
 
-          if (isHorizontalSwipe && onRangeChange) {
-            const panFraction = -dx / dims.w * 0.5;
-            const panAmount = range * panFraction;
-            const newStart = startTs + panAmount;
-            const newEnd = endTs + panAmount;
-            const now = nowTs();
-            if (newEnd <= now && newEnd - newStart >= MIN_RANGE_SEC) {
-              onRangeChange(newStart, newEnd);
-            }
+          if (isHorizontalSwipe && onPan) {
+            const fraction = -dx / dims.w * 0.5;
+            const panAmount = range * fraction;
+            onPan(panAmount);
             touchStartRef.current = { x: touch.clientX, y: touch.clientY };
             return;
           }


### PR DESCRIPTION
## Summary

- Adopts radar/instrument interaction model — reticle fixed at upper third, timeline scrolls underneath, click-to-center with animated transition
- State model: `cursorTs` + `rangeSec` replace `rangeStart`/`rangeEnd`; derived values computed via `useMemo` with reticle-fraction math
- Keyboard: `←→` ±5s, `shift` ±30s, `cmd/ctrl` ±5m (global, skips input fields)

## Interaction changes

- **Scroll = pan**: zoom-aware sensitivity (`panAmountSec`) + velocity acceleration via ref array (no setState)
- **Click = recenter**: 250ms ease-out interpolation using `rAF` + refs exclusively — zero setState per frame
- **Zoom strip**: calls `onZoomChange(newRangeSec)`; `cursorTs` stays fixed so view zooms around reticle
- **Touch**: horizontal-swipe calls `onPan(deltaSec)` (migrated from old `onRangeChange`)

## Invariants preserved

- Reticle Y = `h * RETICLE_FRACTION` (constant, never computed from `cursorTs`)
- `rangeEnd` never exceeds `nowTs() + 60` (clamped in `useMemo`)
- No state in scroll handler — velocity tracking is refs only
- `RETICLE_FRACTION` defined once as module-level export, imported by `VerticalTimeline`
- SplitView unchanged (still uses horizontal `Timeline` + `handleRangeChange`)

## Test notes

- `cd backend && pytest` — 111 passed, no regressions
- Frontend TODO comments added for: keyboard handler, pan acceleration, state derivation, animation ref leak

PR 1 of 7 in timeline redesign. Visual layer overhaul follows in PR4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)