### PR TITLE
feat(frontend): explicit time mapping with zoom presets and bucket resolution

### DIFF
--- a/backend/app/services/time_index.py
+++ b/backend/app/services/time_index.py
@@ -134,31 +134,24 @@ class TimeIndex:
     def auto_resolution(range_sec: float) -> int:
         """Select bucket resolution (seconds per bucket) from range duration.
 
-        < 1h    →   10s  (~360 buckets max)
-        < 4h    →   30s  (~480 buckets max)
-        < 12h   →   60s  (~720 buckets max)
-        < 24h   →  120s  (~720 buckets max)
-        < 72h   →  300s  (~864 buckets max)
-        < 7d    →  600s  (~1008 max; see note)
-        >= 7d   → 1200s
+        Updated for timeline redesign — aligned with tracked object
+        durations (min 5s) and rendering budget (~2000 buckets max for
+        the density-only endpoint).
 
-        Keeps bucket count within frontend rendering budget (~50–900).
-        Note: the < 7d tier can reach ~1008 buckets at exactly 7 days — callers
-        that need hard ≤900 should use the >= 7d tier or pass resolution explicitly.
+        ≤30m  →  5s  (max  360 buckets)
+        ≤1h   →  5s  (max  720 buckets)
+        ≤8h   → 15s  (max 1920 buckets)
+        >8h   → 60s  (max 1440 buckets at 24h)
+
+        Keep in sync with bucketSizeForRange() in frontend/src/utils/time.js.
         """
-        if range_sec < 3600:
-            return 10
-        if range_sec < 14400:
-            return 30
-        if range_sec < 43200:
-            return 60
-        if range_sec < 86400:
-            return 120
-        if range_sec < 259200:
-            return 300
-        if range_sec < 604800:
-            return 600
-        return 1200
+        if range_sec <= 1800:
+            return 5
+        if range_sec <= 3600:
+            return 5
+        if range_sec <= 28800:
+            return 15
+        return 60
 
     # ------------------------------------------------------------------
     # Timeline buckets (Phase 4)

--- a/backend/tests/unit/test_time_index.py
+++ b/backend/tests/unit/test_time_index.py
@@ -100,24 +100,28 @@ class TestEventDensity:
 
 class TestAutoResolution:
     def test_auto_resolution_exact_thresholds(self):
-        """Return values for documented boundary values must match the table exactly."""
+        """Return values for documented boundary values must match the table exactly.
+
+        Must stay in sync with bucketSizeForRange() in frontend/src/utils/time.js.
+        """
         from app.services.time_index import TimeIndex
-        # boundary values: just inside each tier
-        assert TimeIndex.auto_resolution(1800) == 10    # < 1h → 10s
-        assert TimeIndex.auto_resolution(7200) == 30    # < 4h → 30s
-        assert TimeIndex.auto_resolution(21600) == 60   # < 12h → 60s
-        assert TimeIndex.auto_resolution(43200) == 120  # < 24h → 120s
-        assert TimeIndex.auto_resolution(86400) == 300  # < 72h → 300s
-        assert TimeIndex.auto_resolution(259200) == 600 # >= 72h → 600s
+        assert TimeIndex.auto_resolution(1800) == 5    # ≤30m → 5s
+        assert TimeIndex.auto_resolution(3600) == 5    # ≤1h  → 5s
+        assert TimeIndex.auto_resolution(28800) == 15  # ≤8h  → 15s
+        assert TimeIndex.auto_resolution(86400) == 60  # >8h  → 60s
 
     def test_auto_resolution_bucket_count_in_budget(self):
-        """For each range, bucket count must fall within 50–900."""
+        """For each range, bucket count must fall within 50–2000.
+
+        Budget relaxed from 900 to 2000: the density endpoint returns minimal
+        per-bucket payloads (timestamp + counts), so 1920 buckets (8h/15s) is fine.
+        """
         from app.services.time_index import TimeIndex
-        ranges = [3600, 14400, 43200, 86400, 259200, 604800]
+        ranges = [1800, 3600, 28800, 86400]
         for range_sec in ranges:
             res = TimeIndex.auto_resolution(range_sec)
             bucket_count = range_sec / res
-            assert 50 <= bucket_count <= 900, (
+            assert 50 <= bucket_count <= 2000, (
                 f"range={range_sec}s, res={res}s → {bucket_count} buckets (out of budget)"
             )
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -37,7 +37,7 @@ import {
   requestPreviews,
   eventSnapshotUrl,
 } from './utils/api.js';
-import { nowTs, formatDateTime, formatTime } from './utils/time.js';
+import { nowTs, formatDateTime, formatTime, bucketSizeForRange } from './utils/time.js';
 
 // Reticle sits at the upper third of the VerticalTimeline viewport.
 // RETICLE_FRACTION of the range is "future" (above reticle);
@@ -259,6 +259,9 @@ export default function App() {
 
     async function load() {
       try {
+        // bucketSizeForRange selects zoom-appropriate resolution for PR3 density endpoint.
+        // Keep in sync with TimeIndex.auto_resolution() in backend/app/services/time_index.py.
+        const _bucketSize = bucketSizeForRange(rangeSec); // eslint-disable-line no-unused-vars
         const [tl, strip] = await Promise.all([
           fetchTimeline(selectedCamera, rangeStart, rangeEnd),
           fetchPreviewStrip(selectedCamera, rangeStart, rangeEnd, 300),

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -32,7 +32,7 @@
  * is active, falling back to the cursorTs prop when idle.
  */
 
-import { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { formatTimeShort, clampTs, nowTs } from '../utils/time.js';
 import { RETICLE_FRACTION } from '../App.jsx';
 
@@ -47,6 +47,15 @@ function useDebounce(fn, delay) {
 const LABEL_WIDTH = 58;
 const EVENT_WIDTH = 18;
 
+// Named presets for quick-jump buttons (spec Section 6)
+const ZOOM_PRESETS = [
+  { label: '30m', sec: 30 * 60 },
+  { label: '1h',  sec: 60 * 60 },
+  { label: '8h',  sec: 8 * 3600 },
+  { label: '24h', sec: 24 * 3600 },
+];
+
+// Full slider stops — kept for smooth fine-grained zooming
 const ZOOM_STOPS = [
   5 * 60,         // 5m
   8 * 60,         // 8m
@@ -161,14 +170,21 @@ export default function VerticalTimeline({
   // Derive zoom index from live range (no separate state — always in sync)
   const zoomIdx = nearestZoomIdx(range);
 
+  // Explicit seconds-per-pixel mapping — used by tsToY/yToTs and canvas rendering.
+  // Derived, never stored as state. Required by PR4 density gradient rendering.
+  const secondsPerPixel = useMemo(
+    () => (dims.h > 0 ? (endTs - startTs) / dims.h : 1),
+    [startTs, endTs, dims.h]
+  );
+
   const tsToY = useCallback(
-    (ts) => ((ts - startTs) / range) * dims.h,
-    [startTs, range, dims.h]
+    (ts) => (ts - startTs) / secondsPerPixel,
+    [startTs, secondsPerPixel]
   );
 
   const yToTs = useCallback(
-    (y) => clampTs(startTs + (y / dims.h) * range, startTs, endTs),
-    [startTs, endTs, range, dims.h]
+    (y) => clampTs(startTs + y * secondsPerPixel, startTs, endTs),
+    [startTs, endTs, secondsPerPixel]
   );
 
   // ── ResizeObserver ──────────────────────────────────────────────────────────
@@ -315,10 +331,11 @@ export default function VerticalTimeline({
     }
 
     // 7. Time tick labels + horizontal hairlines across bar zone
-    const TICK_INTERVALS = [300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400];
-    const MIN_TICK_SPACING_PX = 28;
+    // Fine-grained intervals (5/10/15/30s) support tight zoom levels.
+    const TICK_INTERVALS = [5, 10, 15, 30, 60, 120, 300, 600, 900, 1800, 3600, 7200, 10800, 21600, 43200, 86400];
+    const MIN_TICK_SPACING_PX = 32;
     const maxTicks = Math.floor(h / MIN_TICK_SPACING_PX);
-    const minIntervalSec = range / maxTicks;
+    const minIntervalSec = (endTs - startTs) / maxTicks;
     const tickSec = TICK_INTERVALS.find((t) => t >= minIntervalSec) ?? 86400;
 
     // Build per-tick-bucket event map for dots
@@ -628,65 +645,95 @@ export default function VerticalTimeline({
       <div
         style={{
           display: 'flex',
-          alignItems: 'center',
-          gap: 6,
-          padding: '6px 8px',
+          flexDirection: 'column',
+          gap: 4,
+          padding: '5px 8px 6px',
           flexShrink: 0,
           borderTop: '1px solid #1e2130',
           background: '#090b10',
         }}
       >
-        {/* − = zoom out = larger range = higher index */}
-        <button
-          style={{
-            ...btnStyle,
-            width: isMobile ? 36 : 28,
-            height: isMobile ? 36 : 28,
-            fontSize: isMobile ? 20 : 16,
-          }}
-          onClick={() => applyZoom(zoomIdx + 1)}
-          disabled={zoomIdx >= ZOOM_STOPS.length - 1}
-          title="Zoom out"
-        >
-          −
-        </button>
+        {/* Preset buttons */}
+        <div style={{ display: 'flex', gap: 4 }}>
+          {ZOOM_PRESETS.map((preset) => {
+            const isActive = Math.abs(range - preset.sec) <= preset.sec * 0.05;
+            return (
+              <button
+                key={preset.label}
+                onClick={() => { if (onZoomChange) onZoomChange(preset.sec); }}
+                style={{
+                  ...btnStyle,
+                  flex: 1,
+                  width: 'auto',
+                  height: 20,
+                  padding: '0 0',
+                  fontSize: 11,
+                  background: isActive ? '#1e3a5c' : '#1a1d27',
+                  color: isActive ? '#90c8f0' : '#888',
+                  border: `1px solid ${isActive ? '#3a6a9c' : '#333'}`,
+                }}
+                title={`Zoom to ${preset.label}`}
+              >
+                {preset.label}
+              </button>
+            );
+          })}
+        </div>
 
-        <input
-          type="range"
-          min={0}
-          max={ZOOM_STOPS.length - 1}
-          value={zoomIdx}
-          onChange={(e) => applyZoom(Number(e.target.value))}
-          style={{ flex: 1, accentColor: '#4a90d9', cursor: 'pointer' }}
-        />
+        {/* Fine slider row */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          {/* − = zoom out = larger range = higher index */}
+          <button
+            style={{
+              ...btnStyle,
+              width: isMobile ? 36 : 28,
+              height: isMobile ? 36 : 28,
+              fontSize: isMobile ? 20 : 16,
+            }}
+            onClick={() => applyZoom(zoomIdx + 1)}
+            disabled={zoomIdx >= ZOOM_STOPS.length - 1}
+            title="Zoom out"
+          >
+            −
+          </button>
 
-        {/* Label: current zoom stop */}
-        <span
-          style={{
-            fontSize: 11,
-            fontFamily: 'monospace',
-            color: '#666',
-            minWidth: 28,
-            textAlign: 'right',
-          }}
-        >
-          {ZOOM_STOP_LABELS[zoomIdx]}
-        </span>
+          <input
+            type="range"
+            min={0}
+            max={ZOOM_STOPS.length - 1}
+            value={zoomIdx}
+            onChange={(e) => applyZoom(Number(e.target.value))}
+            style={{ flex: 1, accentColor: '#4a90d9', cursor: 'pointer' }}
+          />
 
-        {/* + = zoom in = smaller range = lower index */}
-        <button
-          style={{
-            ...btnStyle,
-            width: isMobile ? 36 : 28,
-            height: isMobile ? 36 : 28,
-            fontSize: isMobile ? 20 : 16,
-          }}
-          onClick={() => applyZoom(zoomIdx - 1)}
-          disabled={zoomIdx <= 0}
-          title="Zoom in"
-        >
-          +
-        </button>
+          {/* Label: current zoom stop */}
+          <span
+            style={{
+              fontSize: 11,
+              fontFamily: 'monospace',
+              color: '#666',
+              minWidth: 28,
+              textAlign: 'right',
+            }}
+          >
+            {ZOOM_STOP_LABELS[zoomIdx]}
+          </span>
+
+          {/* + = zoom in = smaller range = lower index */}
+          <button
+            style={{
+              ...btnStyle,
+              width: isMobile ? 36 : 28,
+              height: isMobile ? 36 : 28,
+              fontSize: isMobile ? 20 : 16,
+            }}
+            onClick={() => applyZoom(zoomIdx - 1)}
+            disabled={zoomIdx <= 0}
+            title="Zoom in"
+          >
+            +
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -57,3 +57,25 @@ export function nowTs() {
 export function clampTs(ts, min, max) {
   return Math.min(Math.max(ts, min), max);
 }
+
+/**
+ * Select bucket size (seconds) for a given visible range.
+ *
+ * Aligned with Frigate tracked object durations (typically 5-60s).
+ * Minimum 5s to avoid oversampling the same event across many buckets.
+ * Keeps bucket count under ~2000 for any range.
+ *
+ * Must stay in sync with TimeIndex.auto_resolution() in
+ * backend/app/services/time_index.py.
+ *
+ * TODO: add unit tests verifying sync with TimeIndex.auto_resolution().
+ *
+ * @param {number} rangeSec - visible time range in seconds
+ * @returns {number} bucket size in seconds
+ */
+export function bucketSizeForRange(rangeSec) {
+  if (rangeSec <= 1800)  return 5;   // ≤30m → 5s  (max  360 buckets)
+  if (rangeSec <= 3600)  return 5;   // ≤1h  → 5s  (max  720 buckets)
+  if (rangeSec <= 28800) return 15;  // ≤8h  → 15s (max 1920 buckets)
+  return 60;                          // >8h  → 60s (max ~1440 at 24h)
+}


### PR DESCRIPTION
## Summary

- Adds explicit `secondsPerPixel` model to `VerticalTimeline` — derived value, never state; `tsToY`/`yToTs` refactored to reference it
- Updates zoom presets: 30m / 1h / 8h / 24h quick-jump buttons above fine slider; active preset highlighted
- Aligns bucket resolution: 5s (≤1h), 15s (≤8h), 60s (>8h) — matching table defined in both JS and Python
- Updates `TimeIndex.auto_resolution()` to match new thresholds; relaxes test budget from 900→2000 buckets (density endpoint returns minimal payloads)
- Adds fine-grained tick intervals (5/10/15/30s) with `MIN_TICK_SPACING_PX` bumped to 32
- Exports `bucketSizeForRange()` from `time.js`, imported in `App.jsx` for PR3 density endpoint wiring

PR 2 of 7 in timeline redesign.

## Test plan

- [x] `cd backend && pytest` — all 111 tests pass
- [ ] Verify preset buttons appear above slider in VerticalTimeline
- [ ] Verify active preset highlights at correct zoom level
- [ ] Verify fine-grained tick labels appear at tight zoom (≤5m)
- [ ] Verify `bucketSizeForRange` and `auto_resolution` return identical values for same input

🤖 Generated with [Claude Code](https://claude.com/claude-code)