### PR TITLE
feat(backend): density endpoint and zone sync for timeline redesign

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     frigate_vod_enabled: bool = True
     frigate_vod_window_sec: int = 86400  # width of HLS window to request from Frigate (24 h)
 
+    # Labels that trigger "important" flag in density buckets.
+    # Phase 1: label-only rules. Phase 2 adds zone-based rules.
+    # Override via IMPORTANT_LABELS='["cat","bird","bear"]' in .env
+    important_labels: list[str] = ["cat", "bird", "bear", "horse"]
+
     def ensure_dirs(self):
         """Create required directories if they don't exist."""
         self.preview_output_path.mkdir(parents=True, exist_ok=True)

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -58,7 +58,8 @@ CREATE TABLE IF NOT EXISTS events (
     score           REAL,
     has_clip        INTEGER NOT NULL DEFAULT 0,
     has_snapshot     INTEGER NOT NULL DEFAULT 0,
-    synced_at       REAL NOT NULL
+    synced_at       REAL NOT NULL,
+    zones           TEXT NOT NULL DEFAULT '[]'  -- JSON list of zone names entered
 );
 
 CREATE INDEX IF NOT EXISTS idx_events_camera_time
@@ -82,6 +83,12 @@ def init_db_sync():
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-64000")  # 64MB cache
+    # Idempotent migration: add zones column to existing databases.
+    # New databases already have it from the SCHEMA above.
+    try:
+        conn.execute("ALTER TABLE events ADD COLUMN zones TEXT NOT NULL DEFAULT '[]'")
+    except sqlite3.OperationalError:
+        pass  # column already exists
     conn.commit()
     conn.close()
 

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -119,3 +119,18 @@ class CameraPreviewStatus(BaseModel):
     pending_recent: int       # pending within recency window
     pending_historical: int   # pending outside recency window
     pct_recent_complete: float
+
+
+class DensityBucket(BaseModel):
+    ts: float
+    counts: dict[str, int]
+    total: int
+    important: bool
+
+
+class DensityResponse(BaseModel):
+    camera: str
+    start_ts: float
+    end_ts: float
+    bucket_sec: int
+    buckets: list[DensityBucket]

--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -23,6 +23,8 @@ from app.services.time_index import get_time_index
 from app.models.schemas import (
     ActivityBucket,
     CameraInfo,
+    DensityBucket,
+    DensityResponse,
     EventInfo,
     GapInfo,
     HealthResponse,
@@ -467,6 +469,56 @@ async def get_timeline_buckets(
         "bucket_count": len(buckets),
         "buckets": buckets,
     }
+
+
+@router.get("/timeline/density", response_model=DensityResponse)
+async def get_timeline_density(
+    camera: str = Query(...),
+    start: float = Query(...),
+    end: float = Query(...),
+    bucket_sec: int | None = Query(None, ge=1, le=3600),
+):
+    # INVARIANT: Timeline endpoints are READ-ONLY.
+    # This function must NEVER trigger: preview generation, ffprobe,
+    # filesystem scans, or segment iteration.
+    # If you are adding writes here — stop and reconsider.
+    """Lightweight per-bucket tracked object counts for canvas density rendering.
+
+    Use this during panning instead of the full /api/timeline endpoint.
+    Returns only density data — no segments, gaps, or preview info.
+
+    bucket_sec omitted → auto-selected via TimeIndex.auto_resolution(end - start).
+    Overlapping events are counted in every bucket they span (unlike activity
+    in /api/timeline which counts only at start_ts).
+    """
+    from app.services.time_index import TimeIndex, get_time_index
+
+    if bucket_sec is None:
+        bucket_sec = TimeIndex.auto_resolution(end - start)
+
+    async with get_db() as db:
+        rows = await db.execute_fetchall(
+            """SELECT start_ts, end_ts, label, score, zones
+               FROM events
+               WHERE camera = ?
+                 AND (end_ts IS NULL OR end_ts >= ?)
+                 AND start_ts <= ?
+               ORDER BY start_ts""",
+            (camera, start, end),
+        )
+
+    important_labels = set(settings.important_labels)
+    buckets = get_time_index().compute_density_buckets(
+        rows, start, end, bucket_sec, important_labels=important_labels
+    )
+
+    return DensityResponse(
+        camera=camera,
+        start_ts=start,
+        end_ts=end,
+        bucket_sec=bucket_sec,
+        buckets=[DensityBucket(**b) for b in buckets],
+    )
 
 
 @router.get("/debug/stats")

--- a/backend/app/services/event_sync.py
+++ b/backend/app/services/event_sync.py
@@ -5,6 +5,7 @@ checks `last_event_sync_ts` per camera from `scan_state` and fetches only
 events newer than that, keeping API calls small.
 """
 
+import json
 import logging
 import sqlite3
 import time
@@ -98,6 +99,7 @@ def sync_frigate_events_sync(camera: str | None = None, db_path=None) -> int:
                 rows_to_upsert = []
                 for evt in events:
                     try:
+                        zones_json = json.dumps(evt.get("zones", []))
                         rows_to_upsert.append((
                             str(evt["id"]),
                             cam,
@@ -108,6 +110,7 @@ def sync_frigate_events_sync(camera: str | None = None, db_path=None) -> int:
                             int(bool(evt.get("has_clip", False))),
                             int(bool(evt.get("has_snapshot", False))),
                             now,
+                            zones_json,
                         ))
                     except (KeyError, TypeError, ValueError) as exc:
                         log.debug("Skipping malformed event %s: %s", evt.get("id"), exc)
@@ -115,14 +118,15 @@ def sync_frigate_events_sync(camera: str | None = None, db_path=None) -> int:
                 if rows_to_upsert:
                     conn.executemany(
                         """INSERT INTO events
-                           (id, camera, start_ts, end_ts, label, score, has_clip, has_snapshot, synced_at)
-                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                           (id, camera, start_ts, end_ts, label, score, has_clip, has_snapshot, synced_at, zones)
+                           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                            ON CONFLICT(id) DO UPDATE SET
-                             end_ts      = excluded.end_ts,
-                             score       = excluded.score,
-                             has_clip    = excluded.has_clip,
+                             end_ts       = excluded.end_ts,
+                             score        = excluded.score,
+                             has_clip     = excluded.has_clip,
                              has_snapshot = excluded.has_snapshot,
-                             synced_at   = excluded.synced_at""",
+                             synced_at    = excluded.synced_at,
+                             zones        = excluded.zones""",
                         rows_to_upsert,
                     )
                     total_synced += len(rows_to_upsert)

--- a/backend/app/services/time_index.py
+++ b/backend/app/services/time_index.py
@@ -128,6 +128,72 @@ class TimeIndex:
         ]
 
     # ------------------------------------------------------------------
+    # Density bucketing
+    # ------------------------------------------------------------------
+    def compute_density_buckets(
+        self,
+        events,
+        range_start: float,
+        range_end: float,
+        bucket_sec: int,
+        important_labels: set[str] | None = None,
+    ) -> list[dict]:
+        """Bucket tracked objects with overlap-aware counting.
+
+        A tracked object spanning buckets A through C is counted in A, B, AND C.
+        This gives an accurate density reading for the canvas gradient, unlike
+        start_ts-only bucketing which under-reports long-lived objects.
+
+        events: iterable of DB rows (start_ts, end_ts, label, ...) or dicts
+                with the same keys.
+        important_labels: set of labels that set the important=True flag.
+                          Defaults to {"cat", "bird", "bear", "horse"}.
+
+        Returns list[dict] matching DensityBucket shape:
+          {ts, counts, total, important}
+        """
+        if important_labels is None:
+            important_labels = {"cat", "bird", "bear", "horse"}
+
+        n_buckets = max(1, math.ceil((range_end - range_start) / bucket_sec))
+        result = []
+
+        for i in range(n_buckets):
+            b_start = range_start + i * bucket_sec
+            b_end = b_start + bucket_sec
+            counts: dict[str, int] = {}
+            important = False
+
+            for evt in events:
+                if isinstance(evt, dict):
+                    evt_start = evt["start_ts"]
+                    evt_end = evt.get("end_ts")
+                    evt_label = evt["label"]
+                else:
+                    # DB row: (start_ts, end_ts, label, ...)
+                    evt_start = evt[0]
+                    evt_end = evt[1]
+                    evt_label = evt[2]
+
+                if evt_end is None:
+                    evt_end = evt_start + 5  # active event fallback
+
+                # Overlap check: event spans this bucket
+                if evt_start < b_end and evt_end > b_start:
+                    counts[evt_label] = counts.get(evt_label, 0) + 1
+                    if evt_label in important_labels:
+                        important = True
+
+            result.append({
+                "ts": b_start,
+                "counts": counts,
+                "total": sum(counts.values()),
+                "important": important,
+            })
+
+        return result
+
+    # ------------------------------------------------------------------
     # Resolution selection
     # ------------------------------------------------------------------
     @staticmethod

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -256,6 +256,120 @@ async def test_timeline_buckets_has_preview_from_db_not_filesystem(client, monke
     assert any(has_preview_values), "Expected has_preview=True from DB row, got all False"
 
 
+# ---------------------------------------------------------------------------
+# Density endpoint
+# ---------------------------------------------------------------------------
+
+def _insert_event(db_path, camera, start_ts, end_ts, label="person", zones=None):
+    """Insert a test event row directly into the DB."""
+    import json
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """INSERT INTO events
+               (id, camera, start_ts, end_ts, label, score, has_clip, has_snapshot, synced_at, zones)
+               VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?, ?)""",
+        (f"{camera}-{start_ts}", camera, start_ts, end_ts, label, 0.9, time.time(),
+         json.dumps(zones or [])),
+    )
+    conn.commit()
+    conn.close()
+
+
+async def test_density_endpoint_returns_correct_shape(client):
+    """GET /api/timeline/density returns DensityResponse shape."""
+    resp = await client.get(
+        "/api/timeline/density",
+        params={"camera": "density-cam", "start": 1700000000.0, "end": 1700003600.0},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["camera"] == "density-cam"
+    assert data["start_ts"] == pytest.approx(1700000000.0)
+    assert data["end_ts"] == pytest.approx(1700003600.0)
+    assert "bucket_sec" in data
+    assert isinstance(data["buckets"], list)
+    assert len(data["buckets"]) > 0
+    # Each bucket has required fields
+    bucket = data["buckets"][0]
+    assert "ts" in bucket
+    assert "counts" in bucket
+    assert "total" in bucket
+    assert "important" in bucket
+
+
+async def test_density_endpoint_auto_resolution(client):
+    """Omitting bucket_sec uses auto_resolution based on range."""
+    resp = await client.get(
+        "/api/timeline/density",
+        params={"camera": "auto-res-cam", "start": 1700000000.0, "end": 1700003600.0},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # 1h range → auto_resolution = 5s
+    assert data["bucket_sec"] == 5
+
+
+async def test_density_endpoint_respects_explicit_bucket_sec(client):
+    """Explicit bucket_sec=30 is used verbatim."""
+    resp = await client.get(
+        "/api/timeline/density",
+        params={
+            "camera": "explicit-bucket-cam",
+            "start": 1700000000.0,
+            "end": 1700003600.0,
+            "bucket_sec": 30,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["bucket_sec"] == 30
+    # 1h / 30s = 120 buckets
+    assert len(data["buckets"]) == 120
+
+
+async def test_density_endpoint_counts_events(client):
+    """Events in the range show up as non-zero totals in matching buckets."""
+    from app import config
+    db_path = config.settings.database_path
+    _insert_event(db_path, "count-cam", 1700040010.0, 1700040020.0, label="car")
+
+    resp = await client.get(
+        "/api/timeline/density",
+        params={
+            "camera": "count-cam",
+            "start": 1700040000.0,
+            "end": 1700040060.0,
+            "bucket_sec": 30,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    # First bucket [0, 30) contains the event
+    first = data["buckets"][0]
+    assert first["total"] == 1
+    assert first["counts"].get("car") == 1
+
+
+async def test_density_endpoint_important_flag(client):
+    """Bucket containing a 'cat' event → important=True."""
+    from app import config
+    db_path = config.settings.database_path
+    _insert_event(db_path, "important-cam", 1700050005.0, 1700050010.0, label="cat")
+
+    resp = await client.get(
+        "/api/timeline/density",
+        params={
+            "camera": "important-cam",
+            "start": 1700050000.0,
+            "end": 1700050030.0,
+            "bucket_sec": 30,
+        },
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["buckets"][0]["important"] is True
+
+
 async def test_worker_one_query_per_camera_group(test_app, monkeypatch):
     """10 jobs across 2 cameras → exactly 2 DB execute_fetchall queries issued."""
     from contextlib import asynccontextmanager

--- a/backend/tests/unit/test_density.py
+++ b/backend/tests/unit/test_density.py
@@ -1,0 +1,98 @@
+"""Unit tests for TimeIndex.compute_density_buckets()."""
+
+import pytest
+from app.services.time_index import TimeIndex
+
+
+@pytest.fixture()
+def idx():
+    """TimeIndex instance with default settings (interval irrelevant here)."""
+    from pathlib import Path
+    return TimeIndex(preview_output_path=Path("/tmp"), interval=2.0)
+
+
+class TestComputeDensityBuckets:
+    def test_single_event_in_one_bucket(self, idx):
+        """Event wholly within one bucket is counted only in that bucket."""
+        events = [{"start_ts": 10.0, "end_ts": 20.0, "label": "person"}]
+        buckets = idx.compute_density_buckets(events, 0.0, 60.0, 30)
+        assert buckets[0]["total"] == 1  # bucket [0, 30)
+        assert buckets[1]["total"] == 0  # bucket [30, 60)
+
+    def test_single_event_counted_in_overlapping_buckets(self, idx):
+        """Event spanning 3 buckets must appear in all 3."""
+        # Buckets: [0,10), [10,20), [20,30) — event covers all three
+        events = [{"start_ts": 5.0, "end_ts": 25.0, "label": "car"}]
+        buckets = idx.compute_density_buckets(events, 0.0, 30.0, 10)
+        assert len(buckets) == 3
+        assert buckets[0]["total"] == 1
+        assert buckets[1]["total"] == 1
+        assert buckets[2]["total"] == 1
+
+    def test_empty_range_returns_empty_buckets(self, idx):
+        """All buckets have total=0 when no events exist."""
+        buckets = idx.compute_density_buckets([], 0.0, 60.0, 15)
+        assert all(b["total"] == 0 for b in buckets)
+        assert all(b["counts"] == {} for b in buckets)
+
+    def test_importance_flag_set_for_important_labels(self, idx):
+        """Bucket with a 'cat' event → important=True."""
+        events = [{"start_ts": 5.0, "end_ts": 8.0, "label": "cat"}]
+        buckets = idx.compute_density_buckets(events, 0.0, 30.0, 15)
+        assert buckets[0]["important"] is True
+        assert buckets[1]["important"] is False
+
+    def test_importance_flag_false_for_normal_labels(self, idx):
+        """Bucket with only 'person' events → important=False."""
+        events = [{"start_ts": 5.0, "end_ts": 8.0, "label": "person"}]
+        buckets = idx.compute_density_buckets(events, 0.0, 30.0, 15)
+        assert all(not b["important"] for b in buckets)
+
+    def test_custom_important_labels(self, idx):
+        """Custom important_labels set overrides the default."""
+        events = [{"start_ts": 5.0, "end_ts": 8.0, "label": "person"}]
+        buckets = idx.compute_density_buckets(
+            events, 0.0, 15.0, 15, important_labels={"person"}
+        )
+        assert buckets[0]["important"] is True
+
+    def test_active_event_no_end_time(self, idx):
+        """Event with end_ts=None uses 5s fallback duration."""
+        # Active event at t=5 with no end — fallback end=10
+        events = [{"start_ts": 5.0, "end_ts": None, "label": "person"}]
+        # Bucket [0, 30) should see the event (5..10 overlaps 0..30)
+        buckets = idx.compute_density_buckets(events, 0.0, 30.0, 30)
+        assert buckets[0]["total"] == 1
+
+    def test_counts_per_label_correct(self, idx):
+        """2 person + 1 car in bucket → counts={person:2, car:1}, total=3."""
+        events = [
+            {"start_ts": 5.0,  "end_ts": 8.0,  "label": "person"},
+            {"start_ts": 10.0, "end_ts": 12.0, "label": "person"},
+            {"start_ts": 7.0,  "end_ts": 9.0,  "label": "car"},
+        ]
+        buckets = idx.compute_density_buckets(events, 0.0, 30.0, 30)
+        assert buckets[0]["counts"] == {"person": 2, "car": 1}
+        assert buckets[0]["total"] == 3
+
+    def test_db_row_tuple_input(self, idx):
+        """Accepts DB row tuples (start_ts, end_ts, label, ...) as well as dicts."""
+        # DB rows: (start_ts, end_ts, label, score, zones)
+        events = [(5.0, 8.0, "person", 0.9, "[]")]
+        buckets = idx.compute_density_buckets(events, 0.0, 30.0, 30)
+        assert buckets[0]["counts"] == {"person": 1}
+        assert buckets[0]["total"] == 1
+
+    def test_bucket_count_matches_range(self, idx):
+        """Number of buckets = ceil((end - start) / bucket_sec)."""
+        buckets = idx.compute_density_buckets([], 0.0, 100.0, 30)
+        # ceil(100 / 30) = 4
+        assert len(buckets) == 4
+
+    def test_event_at_bucket_boundary_inclusive(self, idx):
+        """Event starting exactly at bucket boundary goes into that bucket."""
+        # event [30, 40) — should be in bucket [30, 60), not [0, 30)
+        events = [{"start_ts": 30.0, "end_ts": 40.0, "label": "dog"}]
+        buckets = idx.compute_density_buckets(events, 0.0, 60.0, 30)
+        assert buckets[0]["total"] == 0
+        assert buckets[1]["total"] == 1

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -30,6 +30,7 @@ import AdminPanel from './components/AdminPanel.jsx';
 import SplitView from './components/SplitView.jsx';
 import {
   fetchCameras,
+  fetchDensity,
   fetchTimeline,
   fetchPreviewStrip,
   fetchPlaybackTarget,
@@ -145,6 +146,7 @@ export default function App() {
   const [multiMode, setMultiMode] = useState(false);
 
   const [timelineData, setTimelineData] = useState(null);
+  const [densityData, setDensityData] = useState(null);
   const [previewFrames, setPreviewFrames] = useState([]);
   const [cursorTs, setCursorTs] = useState(() => nowTs());
   const [rangeSec, setRangeSec] = useState(8 * 3600);
@@ -281,6 +283,25 @@ export default function App() {
     load();
     return () => { cancelled = true; };
   }, [selectedCamera, rangeStart, rangeEnd, multiMode]);
+
+  // ─── Debounced density fetch (pan-optimized) ───
+  // Fires 100ms after range changes to coalesce rapid pan events.
+  // The full timeline fetch above stays as the source of truth for
+  // segments/gaps; this provides lightweight density updates during scrolling.
+  // TODO: add frontend test verifying this fires at most once per 100ms burst.
+  useEffect(() => {
+    if (!selectedCamera || multiMode) return;
+    const timer = setTimeout(async () => {
+      try {
+        const bucketSec = bucketSizeForRange(rangeSec);
+        const density = await fetchDensity(selectedCamera, rangeStart, rangeEnd, bucketSec);
+        setDensityData(density);
+      } catch {
+        // Density is best-effort — don't surface errors for pan-time fetches
+      }
+    }, 100);
+    return () => clearTimeout(timer);
+  }, [selectedCamera, rangeStart, rangeEnd, rangeSec, multiMode]);
 
   // ─── Derived label lists ───
   const availableLabels = useMemo(() => {

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -110,6 +110,25 @@ export function eventSnapshotUrl(eventId) {
   return `${API_BASE}/events/${eventId}/snapshot`;
 }
 
+/**
+ * GET /api/timeline/density?camera=X&start=Y&end=Z&bucket_sec=N
+ *
+ * Lightweight density data for canvas rendering. Use during panning
+ * instead of the full /api/timeline endpoint — returns only per-bucket
+ * tracked object counts (no segments, gaps, or preview info).
+ *
+ * TODO: add unit tests verifying bucket shape matches DensityResponse schema.
+ */
+export async function fetchDensity(camera, startTs, endTs, bucketSec) {
+  const params = new URLSearchParams({
+    camera,
+    start: String(startTs),
+    end: String(endTs),
+  });
+  if (bucketSec != null) params.set('bucket_sec', String(bucketSec));
+  return apiFetch(`/timeline/density?${params}`);
+}
+
 /** GET /api/health */
 export async function fetchHealth() {
   return apiFetch('/health');


### PR DESCRIPTION
## Summary

- Adds `GET /api/timeline/density` — lightweight per-bucket tracked object counts optimized for scroll-time fetches (no segments, gaps, or preview info)
- Overlap-aware counting: `TimeIndex.compute_density_buckets()` counts events in every bucket they span, not just the start bucket
- Syncs `zones` from Frigate events API into local DB; idempotent `ALTER TABLE` migration for existing installs
- Adds configurable `important_labels` setting (Phase 1 label-only rules, e.g. cat/bird/bear/horse)
- Adds `DensityBucket` + `DensityResponse` Pydantic models
- Frontend: `fetchDensity()` API client + 100ms debounced density `useEffect` in `App.jsx`; `densityData` state ready for PR4 canvas rendering

PR 3 of 7 in timeline redesign. Unblocks canvas density rendering (PR4).

## Test plan

- [x] `cd backend && pytest` — 127 tests pass (16 new)
- [ ] Verify `GET /api/timeline/density` returns correct bucket shape
- [ ] Verify `bucket_sec` auto-selected at 5s for 1h range
- [ ] Verify events spanning bucket boundaries appear in multiple buckets
- [ ] Verify `important=true` for cat/bird/bear/horse labels
- [ ] Verify zones column added to existing DB without breaking anything
- [ ] Verify density fetch fires in browser during pan (Network tab, 100ms debounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)