### PR TITLE
feat(frontend): event navigation with importance filtering

### DIFF
--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -507,9 +507,8 @@ async def get_timeline_density(
             (camera, start, end),
         )
 
-    important_labels = set(settings.important_labels)
     buckets = get_time_index().compute_density_buckets(
-        rows, start, end, bucket_sec, important_labels=important_labels
+        rows, start, end, bucket_sec
     )
 
     return DensityResponse(

--- a/backend/app/services/time_index.py
+++ b/backend/app/services/time_index.py
@@ -136,7 +136,7 @@ class TimeIndex:
         range_start: float,
         range_end: float,
         bucket_sec: int,
-        important_labels: set[str] | None = None,
+        importance_fn=None,
     ) -> list[dict]:
         """Bucket tracked objects with overlap-aware counting.
 
@@ -146,14 +146,27 @@ class TimeIndex:
 
         events: iterable of DB rows (start_ts, end_ts, label, ...) or dicts
                 with the same keys.
-        important_labels: set of labels that set the important=True flag.
-                          Defaults to {"cat", "bird", "bear", "horse"}.
+        importance_fn: callable(event_dict) -> bool
+            If None, uses label-based default from settings.important_labels.
+            Phase 2 will pass a zone-aware predicate here — the density endpoint
+            stays unchanged; only the predicate changes.
 
         Returns list[dict] matching DensityBucket shape:
           {ts, counts, total, important}
         """
-        if important_labels is None:
-            important_labels = {"cat", "bird", "bear", "horse"}
+        # TODO: Phase 2 — pass a zone-aware predicate from the router so that
+        # importance is determined by label + zone membership, not label alone.
+        # Example predicate:
+        #   def zone_importance(evt):
+        #       return (
+        #           evt["label"] == "person"
+        #           and "front_yard" in json.loads(evt.get("zones", "[]"))
+        #       ) or evt["label"] in {"cat", "bird", "bear", "horse"}
+        # The important_labels config must stay in sync with any hardcoded
+        # frontend Phase 1 label list (see App.jsx isImportant).
+        if importance_fn is None:
+            important_set = set(settings.important_labels)
+            importance_fn = lambda evt: evt.get("label") in important_set  # noqa: E731
 
         n_buckets = max(1, math.ceil((range_end - range_start) / bucket_sec))
         result = []
@@ -169,11 +182,13 @@ class TimeIndex:
                     evt_start = evt["start_ts"]
                     evt_end = evt.get("end_ts")
                     evt_label = evt["label"]
+                    evt_dict = evt
                 else:
                     # DB row: (start_ts, end_ts, label, ...)
                     evt_start = evt[0]
                     evt_end = evt[1]
                     evt_label = evt[2]
+                    evt_dict = {"start_ts": evt[0], "end_ts": evt[1], "label": evt[2]}
 
                 if evt_end is None:
                     evt_end = evt_start + 5  # active event fallback
@@ -181,7 +196,7 @@ class TimeIndex:
                 # Overlap check: event spans this bucket
                 if evt_start < b_end and evt_end > b_start:
                     counts[evt_label] = counts.get(evt_label, 0) + 1
-                    if evt_label in important_labels:
+                    if not important and importance_fn(evt_dict):
                         important = True
 
             result.append({

--- a/backend/tests/unit/test_density.py
+++ b/backend/tests/unit/test_density.py
@@ -48,13 +48,22 @@ class TestComputeDensityBuckets:
         buckets = idx.compute_density_buckets(events, 0.0, 30.0, 15)
         assert all(not b["important"] for b in buckets)
 
-    def test_custom_important_labels(self, idx):
-        """Custom important_labels set overrides the default."""
+    def test_custom_importance_fn(self, idx):
+        """Custom importance_fn overrides the default label-based predicate."""
         events = [{"start_ts": 5.0, "end_ts": 8.0, "label": "person"}]
         buckets = idx.compute_density_buckets(
-            events, 0.0, 15.0, 15, important_labels={"person"}
+            events, 0.0, 15.0, 15, importance_fn=lambda evt: evt["label"] == "person"
         )
         assert buckets[0]["important"] is True
+
+    def test_custom_importance_fn_false(self, idx):
+        """Custom importance_fn returning False leaves bucket non-important."""
+        events = [{"start_ts": 5.0, "end_ts": 8.0, "label": "cat"}]
+        # Even though 'cat' is in the default set, a custom fn overrides
+        buckets = idx.compute_density_buckets(
+            events, 0.0, 15.0, 15, importance_fn=lambda evt: evt["label"] == "person"
+        )
+        assert buckets[0]["important"] is False
 
     def test_active_event_no_end_time(self, idx):
         """Event with end_ts=None uses 5s fallback duration."""

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -147,6 +147,11 @@ export default function App() {
 
   const [timelineData, setTimelineData] = useState(null);
   const [densityData, setDensityData] = useState(null);
+  const [currentEventIndex, setCurrentEventIndex] = useState(null);
+  // TODO: importantOnly and the Phase 1 label set must stay in sync with
+  // settings.important_labels in backend/app/config.py. Consider fetching
+  // the list from a /api/config endpoint in Phase 2 instead of hardcoding.
+  const [importantOnly, setImportantOnly] = useState(false);
   const [previewFrames, setPreviewFrames] = useState([]);
   const [cursorTs, setCursorTs] = useState(() => nowTs());
   const [rangeSec, setRangeSec] = useState(8 * 3600);
@@ -315,6 +320,17 @@ export default function App() {
     return timelineData.events.filter(e => activeLabels.has(e.label));
   }, [timelineData, activeLabels]);
 
+  // Phase 1 importance: label-based hardcoded set.
+  // TODO: sync with settings.important_labels in backend/app/config.py.
+  // Phase 2 will fetch this list from a shared config endpoint.
+  // TODO: unit test — verify importantOnly correctly filters navEvents list
+  // and that currentEventIndex stays in bounds after filteredEvents changes.
+  const IMPORTANT_LABELS = useMemo(() => new Set(['cat', 'bird', 'bear', 'horse']), []);
+  const navEvents = useMemo(() => {
+    const sorted = [...filteredEvents].sort((a, b) => a.start_ts - b.start_ts);
+    return importantOnly ? sorted.filter(e => IMPORTANT_LABELS.has(e.label)) : sorted;
+  }, [filteredEvents, importantOnly, IMPORTANT_LABELS]);
+
   // ─── Range change — kept for SplitView backward compat ───
   const handleRangeChange = useCallback((newStart, newEnd) => {
     const newRange = newEnd - newStart;
@@ -456,17 +472,22 @@ export default function App() {
 
   // ─── Event navigation ───
   const navigateEvent = useCallback(async (direction) => {
-    if (!filteredEvents.length) return;
-    const sorted = [...filteredEvents].sort((a, b) => a.start_ts - b.start_ts);
+    if (!navEvents.length) return;
     const current = cursorTs ?? 0;
 
-    let target;
+    let targetIdx;
     if (direction === 'next') {
-      target = sorted.find(e => e.start_ts > current + 1) ?? sorted[0];
+      const idx = navEvents.findIndex(e => e.start_ts > current + 1);
+      targetIdx = idx >= 0 ? idx : 0;
     } else {
-      target = [...sorted].reverse().find(e => e.start_ts < current - 1)
-               ?? sorted[sorted.length - 1];
+      const idx = [...navEvents].map((e, i) => i).reverse().find(
+        i => navEvents[i].start_ts < current - 1
+      );
+      targetIdx = idx != null ? idx : navEvents.length - 1;
     }
+
+    const target = navEvents[targetIdx];
+    setCurrentEventIndex(targetIdx);
 
     if (!target) return;
 
@@ -489,7 +510,7 @@ export default function App() {
     }
 
     // setCursorTs(target.start_ts) above recenters the derived range automatically
-  }, [filteredEvents, cursorTs, selectedCamera]);
+  }, [navEvents, cursorTs, selectedCamera]);
 
   // ─── Derive scrub preview URL ───
   const activePreviewUrl =
@@ -732,15 +753,71 @@ export default function App() {
         </div>
       )}
 
-      {/* Label filter pills (single-camera mode only) */}
+      {/* Label filter pills + event navigator (single-camera mode only) */}
       {!multiMode && (
-        <LabelFilterPills
-          availableLabels={availableLabels}
-          activeLabels={activeLabels}
-          onToggle={toggleLabel}
-          onToggleAll={toggleAllLabels}
-          isMobile={isMobile}
-        />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', flexShrink: 0 }}>
+          <LabelFilterPills
+            availableLabels={availableLabels}
+            activeLabels={activeLabels}
+            onToggle={toggleLabel}
+            onToggleAll={toggleAllLabels}
+            isMobile={isMobile}
+          />
+
+          {navEvents.length > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto', flexShrink: 0 }}>
+              {/* Event navigator */}
+              <div style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                background: 'rgba(255,255,255,0.04)',
+                border: '1px solid #333',
+                borderRadius: 6,
+                padding: '4px 12px',
+                fontFamily: 'monospace',
+                fontSize: 13,
+                fontWeight: 700,
+                color: '#e0e0e0',
+              }}>
+                <button
+                  onClick={() => navigateEvent('prev')}
+                  style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: 14, padding: 0, fontFamily: 'monospace' }}
+                  onMouseEnter={e => e.target.style.color = '#4dd0e1'}
+                  onMouseLeave={e => e.target.style.color = '#aaa'}
+                  title="Previous event"
+                >◀</button>
+                <span>
+                  EVENT {currentEventIndex != null ? currentEventIndex + 1 : '—'} / {navEvents.length}
+                  {importantOnly && ' ⚡'}
+                </span>
+                <button
+                  onClick={() => navigateEvent('next')}
+                  style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: 14, padding: 0, fontFamily: 'monospace' }}
+                  onMouseEnter={e => e.target.style.color = '#4dd0e1'}
+                  onMouseLeave={e => e.target.style.color = '#aaa'}
+                  title="Next event"
+                >▶</button>
+              </div>
+
+              {/* Important-only toggle */}
+              <button
+                onClick={() => { setImportantOnly(v => !v); setCurrentEventIndex(null); }}
+                title={importantOnly ? 'Showing important events only — click to show all' : 'Click to show important events only'}
+                style={{
+                  background: importantOnly ? 'rgba(77,208,225,0.1)' : 'rgba(255,255,255,0.04)',
+                  border: `1px solid ${importantOnly ? '#4dd0e1' : '#333'}`,
+                  color: importantOnly ? '#4dd0e1' : '#666',
+                  borderRadius: 6,
+                  padding: '4px 10px',
+                  cursor: 'pointer',
+                  fontFamily: 'monospace',
+                  fontSize: 14,
+                }}
+              >⚡</button>
+            </div>
+          )}
+        </div>
       )}
 
       {/* Main content */}
@@ -827,27 +904,6 @@ export default function App() {
                 }}
               />
             </div>
-
-            {/* Prev/Next event navigation */}
-            {filteredEvents.length > 0 && (
-              <div style={{
-                display: 'flex', alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: '4px 8px',
-                borderTop: '1px solid #1e2130',
-                flexShrink: 0,
-              }}>
-                <button onClick={() => navigateEvent('prev')} style={styles.navBtn}>
-                  ‹ prev
-                </button>
-                <span style={{ fontSize: 10, color: '#444', fontFamily: 'monospace' }}>
-                  {filteredEvents.length} evt
-                </span>
-                <button onClick={() => navigateEvent('next')} style={styles.navBtn}>
-                  next ›
-                </button>
-              </div>
-            )}
 
             {/* Bottom range label */}
             <div style={{ ...styles.rangeLabel, borderTop: '1px solid #1e2130', borderBottom: 'none' }}>
@@ -966,16 +1022,6 @@ const styles = {
     color: '#555',
     borderBottom: '1px solid #1e2130',
     flexShrink: 0,
-    fontFamily: 'monospace',
-  },
-  navBtn: {
-    background: '#1a1d27',
-    border: '1px solid #333',
-    color: '#aaa',
-    padding: '4px 10px',
-    borderRadius: 4,
-    cursor: 'pointer',
-    fontSize: 12,
     fontFamily: 'monospace',
   },
   loading: { color: '#888', textAlign: 'center', paddingTop: 100, fontSize: 16 },


### PR DESCRIPTION
## Summary

- Moves event nav to controls bar: bold `EVENT 3 / 9` with `◀` `▶` buttons
- Adds `⚡` toggle for important-only navigation (cyan highlight when active)
- Counter shows `EVENT 1 / 3 ⚡` in important-only mode
- Phase 1 importance: label-based hardcoded set (cat, bird, bear, horse) — must stay in sync with \`settings.important_labels\`
- Removes old prev/next nav from VerticalTimeline column footer
- Backend: refactors \`compute_density_buckets\` to accept \`importance_fn\` predicate; defaults to \`settings.important_labels\` (no behavior change)
- Phase 2 prep: zone-aware predicate can be passed without touching the endpoint

## Test plan

- [ ] 128 backend pytest tests pass (no regressions, 1 new)
- [ ] Event nav shows `EVENT — / N` when no event selected, `EVENT 3 / N` after navigation
- [ ] `◀` / `▶` buttons cycle through events; hover color changes to cyan
- [ ] `⚡` toggle highlighted (cyan border) when important-only mode active
- [ ] Important-only: counter resets to `—` when mode is toggled
- [ ] No event nav rendered in VerticalTimeline column footer
- [ ] `importance_fn=None` (default) uses `settings.important_labels` — existing behavior preserved
- [ ] Custom `importance_fn` respected: `test_custom_importance_fn` passes

PR 5 of 7 in timeline redesign. Depends on PR4 (feat(frontend): radar-style canvas layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)