### PR TITLE
fix(frontend+backend): NaN cascade on camera switch, circular import, segment advance, density query, preview concurrency

### DIFF
--- a/backend/app/routers/preview.py
+++ b/backend/app/routers/preview.py
@@ -45,6 +45,10 @@ log = logging.getLogger(__name__)
 # Strong references to active on-demand tasks — prevents GC before completion
 _active_demand_tasks: set[asyncio.Task] = set()
 
+# Limit concurrent on-demand preview generation tasks to avoid overwhelming ffmpeg.
+# At most 3 tasks run concurrently; additional requests queue behind the semaphore.
+_demand_semaphore = asyncio.Semaphore(3)
+
 
 # ---------------------------------------------------------------------------
 # LRU image cache
@@ -274,10 +278,11 @@ async def request_previews(
     get_scheduler().enqueue_viewport(camera, start, end)
 
     async def _run():
-        try:
-            await process_pending_async(limit=30, min_start_ts=start)
-        except Exception:
-            pass
+        async with _demand_semaphore:
+            try:
+                await process_pending_async(limit=30, min_start_ts=start)
+            except Exception:
+                pass
 
     task = asyncio.create_task(_run())
     _active_demand_tasks.add(task)

--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -498,7 +498,7 @@ async def get_timeline_density(
 
     async with get_db() as db:
         rows = await db.execute_fetchall(
-            """SELECT start_ts, end_ts, label, score, zones
+            """SELECT start_ts, end_ts, label
                FROM events
                WHERE camera = ?
                  AND (end_ts IS NULL OR end_ts >= ?)

--- a/backend/tests/unit/test_preview_concurrency.py
+++ b/backend/tests/unit/test_preview_concurrency.py
@@ -1,0 +1,12 @@
+"""Verify the on-demand preview semaphore limits concurrent tasks."""
+import asyncio
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_demand_semaphore_limits_concurrency():
+    """_demand_semaphore should exist and allow at most 3 concurrent tasks."""
+    from app.routers.preview import _demand_semaphore
+    assert isinstance(_demand_semaphore, asyncio.Semaphore)
+    # Internal value reflects the configured limit of 3
+    assert _demand_semaphore._value == 3  # noqa: SLF001

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,17 +34,13 @@ import {
   fetchTimeline,
   fetchPreviewStrip,
   fetchPlaybackTarget,
+  fetchSegmentInfo,
   fetchHealth,
   requestPreviews,
   eventSnapshotUrl,
 } from './utils/api.js';
 import { nowTs, formatDateTime, formatTime, bucketSizeForRange } from './utils/time.js';
-
-// Reticle sits at the upper third of the VerticalTimeline viewport.
-// RETICLE_FRACTION of the range is "future" (above reticle);
-// (1 - RETICLE_FRACTION) is "past" (below reticle).
-// Exported so VerticalTimeline can use the same value for rendering.
-export const RETICLE_FRACTION = 1 / 3;
+import { RETICLE_FRACTION } from './utils/constants.js';
 
 // Autoplay: idle threshold before timeline starts advancing.
 const AUTOPLAY_DELAY_MS = 1500;
@@ -170,9 +166,14 @@ export default function App() {
   // TODO: during video playback, cursorTs updates at ~30Hz; each update drives a
   //   rangeStart/rangeEnd change that triggers the data-fetch useEffect — consider
   //   debouncing in a follow-up PR if this causes excessive backend requests
+  // Defensive guard: cursorTs should never be null after init, but if a future
+  // code path sets it to null the fallback prevents NaN from cascading into
+  // API requests, the RAF autoplay loop, and event navigation.
+  // TODO: add frontend test verifying rangeStart/rangeEnd never NaN on camera switch.
   const { rangeStart, rangeEnd } = useMemo(() => {
-    const start = cursorTs - rangeSec * (1 - RETICLE_FRACTION);
-    const end = Math.min(cursorTs + rangeSec * RETICLE_FRACTION, nowTs() + 60);
+    const cursor = cursorTs ?? nowTs();
+    const start = cursor - rangeSec * (1 - RETICLE_FRACTION);
+    const end = Math.min(cursor + rangeSec * RETICLE_FRACTION, nowTs() + 60);
     return { rangeStart: start, rangeEnd: end };
   }, [cursorTs, rangeSec]);
 
@@ -494,20 +495,31 @@ export default function App() {
     [selectedCamera]
   );
 
-  // ─── Segment advance: fixes cursor drift bug ───
-  // TODO: add test verifying onSegmentAdvance prop is stable across
-  // cursorTs updates (does not change reference on timeupdate events)
+  // ─── Segment advance: resolves nextSegmentId → start_ts via fetchSegmentInfo ───
+  // Previously read playbackTargetRef directly, which could be null after a camera
+  // switch, causing fetchPlaybackTarget to be called at ts=0. Now uses the
+  // segment ID VideoPlayer provides, with a ref-based fallback if the lookup fails.
+  // TODO: add frontend test verifying onSegmentAdvance is stable across cursorTs updates.
   const handleSegmentAdvance = useCallback(
     async (nextSegmentId) => {
-      if (!selectedCamera) return;
+      if (!selectedCamera || !nextSegmentId) return;
       try {
-        const nextTs = playbackTargetRef.current?.segment_end_ts ?? (cursorTsRef.current ?? 0);
-        const target = await fetchPlaybackTarget(selectedCamera, nextTs + 0.1);
+        const info = await fetchSegmentInfo(nextSegmentId);
+        const target = await fetchPlaybackTarget(selectedCamera, info.start_ts + 0.1);
         console.log('[APP] setPlaybackTarget from auto-advance', target);
         setPlaybackTarget(target);
-      } catch {}
+      } catch {
+        // Fallback: use segment_end_ts from the ref if segment info lookup fails.
+        const fallbackTs = playbackTargetRef.current?.segment_end_ts;
+        if (fallbackTs) {
+          try {
+            const target = await fetchPlaybackTarget(selectedCamera, fallbackTs + 0.1);
+            setPlaybackTarget(target);
+          } catch {}
+        }
+      }
     },
-    [selectedCamera]   // no longer depends on cursorTs or playbackTarget
+    [selectedCamera]
   );
 
   // ─── Playback time tracking ───
@@ -521,15 +533,22 @@ export default function App() {
   }, []);
 
   // ─── Camera switch ───
+  // Uses cam.latest_ts (from /api/cameras) so the new camera's reticle lands at
+  // its most recent footage rather than the previous camera's time position.
+  // Falls back to nowTs() — never sets cursorTs to null which would NaN-cascade
+  // into rangeStart/rangeEnd, API fetches, and the autoplay RAF loop.
   const handleCameraChange = useCallback((name) => {
     setSelectedCamera(name);
-    setCursorTs(null);
+    const cam = cameras.find(c => c.name === name);
+    setCursorTs(cam?.latest_ts ?? nowTs());
     setHoverTs(null);
     setPlaybackTarget(null);
     setTimelineData(null);
+    setDensityData(null);
     setPreviewFrames([]);
     setActiveEventSnapshot(null);
-  }, []);
+    setCurrentEventIndex(null);
+  }, [cameras]);
 
   // ─── Multi-camera selection ───
   const handleSelectMany = useCallback((names) => {

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -34,7 +34,7 @@
 
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { formatTimeShort, clampTs, nowTs } from '../utils/time.js';
-import { RETICLE_FRACTION } from '../App.jsx';
+import { RETICLE_FRACTION } from '../utils/constants.js';
 
 function useDebounce(fn, delay) {
   const timer = useRef(null);

--- a/frontend/src/utils/constants.js
+++ b/frontend/src/utils/constants.js
@@ -1,0 +1,8 @@
+/**
+ * Reticle sits at the upper third of the VerticalTimeline viewport.
+ * RETICLE_FRACTION of the range is "future" (above reticle);
+ * (1 - RETICLE_FRACTION) is "past" (below reticle).
+ * Imported by both App.jsx and VerticalTimeline.jsx — kept here to break
+ * the circular App ↔ VerticalTimeline import dependency.
+ */
+export const RETICLE_FRACTION = 1 / 3;


### PR DESCRIPTION
## Summary

Five bugs found in post-PR7 code review, ranging from critical to low severity.

## Fix 1 — CRITICAL: NaN cascade on camera switch

`handleCameraChange` called `setCursorTs(null)`. This caused `rangeStart = null - number = NaN`, which cascaded to:
- API requests with NaN params (FastAPI 422 → "Timeline load failed")
- RAF autoplay loop computing `null + advanceSec = NaN`, never recovering
- `navigateEvent` falling back to epoch 0

**Fix:** `setCursorTs(cam?.latest_ts ?? nowTs())` — lands on the new camera's most recent footage. Added defensive `cursorTs ?? nowTs()` guard in the `rangeStart`/`rangeEnd` useMemo so null can never cascade even if a future path sets it. Also added `setDensityData(null)` and `setCurrentEventIndex(null)` to the reset list.

## Fix 2 — MEDIUM: Circular import

`App.jsx` exported `RETICLE_FRACTION`; `VerticalTimeline.jsx` imported it from `App.jsx`. Works via ES module hoisting but fragile.

**Fix:** New `frontend/src/utils/constants.js` owns the constant. Both files import from there. No behavior change.

## Fix 3 — MEDIUM: handleSegmentAdvance ignores nextSegmentId

Read `playbackTargetRef.current?.segment_end_ts` instead of using `nextSegmentId`. If the ref was null (e.g. after camera switch), fallback was `cursorTsRef.current ?? 0` — would fetch playback at timestamp 0.

**Fix:** `fetchSegmentInfo(nextSegmentId)` → `fetchPlaybackTarget(camera, info.start_ts + 0.1)` with ref-based fallback if the lookup fails.

## Fix 4 — LOW: Density query selected unused columns

`SELECT start_ts, end_ts, label, score, zones` — `compute_density_buckets` only reads columns 0–2.

**Fix:** `SELECT start_ts, end_ts, label`

## Fix 5 — LOW: Unbounded preview concurrency

`asyncio.create_task(_run())` with no concurrency limit — rapid scrubbing could spawn many concurrent ffmpeg processes.

**Fix:** `_demand_semaphore = asyncio.Semaphore(3)` at module level; `_run()` acquires it before calling `process_pending_async`.

## Test plan

- [ ] 129 backend tests pass (1 new: `test_demand_semaphore_limits_concurrency`)
- [ ] Switch cameras → timeline loads immediately (no NaN, no "Timeline load failed")
- [ ] Reticle lands near the new camera's latest footage timestamp
- [ ] No circular import warning from bundler / linter
- [ ] Auto-advance (segment end) works correctly; no ts=0 playback request
- [ ] Density endpoint responds correctly (columns 0–2 still intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)