### PR TITLE
fix(frontend): debounce + abort timeline fetches to prevent connection exhaustion

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -163,9 +163,6 @@ export default function App() {
   //   rangeStart = cursorTs - rangeSec * (1 - RETICLE_FRACTION)  [past below reticle]
   //   rangeEnd   = cursorTs + rangeSec * RETICLE_FRACTION         [future above reticle]
   // TODO: verify rangeEnd never exceeds nowTs() + 60, rangeStart = cursorTs - rangeSec * (1 - RETICLE_FRACTION)
-  // TODO: during video playback, cursorTs updates at ~30Hz; each update drives a
-  //   rangeStart/rangeEnd change that triggers the data-fetch useEffect — consider
-  //   debouncing in a follow-up PR if this causes excessive backend requests
   // Defensive guard: cursorTs should never be null after init, but if a future
   // code path sets it to null the fallback prevents NaN from cascading into
   // API requests, the RAF autoplay loop, and event navigation.
@@ -345,20 +342,21 @@ export default function App() {
   }, []);
 
   // ─── Load timeline + previews (single camera mode) ───
+  // Debounced 300ms + AbortController: prevents connection exhaustion when
+  // autoplay or rapid scrubbing drives rangeStart/rangeEnd at ~60fps.
+  // TODO: add frontend test verifying at most 1 in-flight timeline request
+  // exists at any time — debounce + abort should make this hold true.
   useEffect(() => {
     if (!selectedCamera || multiMode) return;
-    let cancelled = false;
+    const controller = new AbortController();
 
-    async function load() {
+    const timer = setTimeout(async () => {
       try {
-        // bucketSizeForRange selects zoom-appropriate resolution for PR3 density endpoint.
-        // Keep in sync with TimeIndex.auto_resolution() in backend/app/services/time_index.py.
-        const _bucketSize = bucketSizeForRange(rangeSec); // eslint-disable-line no-unused-vars
+        const opts = { signal: controller.signal };
         const [tl, strip] = await Promise.all([
-          fetchTimeline(selectedCamera, rangeStart, rangeEnd),
-          fetchPreviewStrip(selectedCamera, rangeStart, rangeEnd, 300),
+          fetchTimeline(selectedCamera, rangeStart, rangeEnd, opts),
+          fetchPreviewStrip(selectedCamera, rangeStart, rangeEnd, 300, opts),
         ]);
-        if (cancelled) return;
 
         setTimelineData(tl);
         setPreviewFrames(strip.frames || []);
@@ -366,12 +364,12 @@ export default function App() {
 
         requestPreviews(selectedCamera, rangeStart, rangeEnd).catch(() => {});
       } catch (err) {
-        if (!cancelled) setError(`Timeline load failed: ${err.message}`);
+        if (err.name === 'AbortError') return;
+        setError(`Timeline load failed: ${err.message}`);
       }
-    }
+    }, 300);
 
-    load();
-    return () => { cancelled = true; };
+    return () => { controller.abort(); clearTimeout(timer); };
   }, [selectedCamera, rangeStart, rangeEnd, multiMode]);
 
   // ─── Debounced density fetch (pan-optimized) ───
@@ -381,16 +379,17 @@ export default function App() {
   // TODO: add frontend test verifying this fires at most once per 100ms burst.
   useEffect(() => {
     if (!selectedCamera || multiMode) return;
+    const controller = new AbortController();
     const timer = setTimeout(async () => {
       try {
         const bucketSec = bucketSizeForRange(rangeSec);
-        const density = await fetchDensity(selectedCamera, rangeStart, rangeEnd, bucketSec);
+        const density = await fetchDensity(selectedCamera, rangeStart, rangeEnd, bucketSec, { signal: controller.signal });
         setDensityData(density);
       } catch {
         // Density is best-effort — don't surface errors for pan-time fetches
       }
     }, 100);
-    return () => clearTimeout(timer);
+    return () => { controller.abort(); clearTimeout(timer); };
   }, [selectedCamera, rangeStart, rangeEnd, rangeSec, multiMode]);
 
   // ─── Derived label lists ───

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -21,23 +21,23 @@ export async function fetchCameras() {
 }
 
 /** GET /api/timeline?camera=X&start=Y&end=Z */
-export async function fetchTimeline(camera, startTs, endTs) {
+export async function fetchTimeline(camera, startTs, endTs, options = {}) {
   const params = new URLSearchParams({
     camera,
     start: String(startTs),
     end: String(endTs),
   });
-  return apiFetch(`/timeline?${params}`);
+  return apiFetch(`/timeline?${params}`, options);
 }
 
 /** GET /api/preview-strip/{camera}?start=X&end=Y&max_frames=N */
-export async function fetchPreviewStrip(camera, startTs, endTs, maxFrames = 300) {
+export async function fetchPreviewStrip(camera, startTs, endTs, maxFrames = 300, options = {}) {
   const params = new URLSearchParams({
     start: String(startTs),
     end: String(endTs),
     max_frames: String(maxFrames),
   });
-  return apiFetch(`/preview-strip/${camera}?${params}`);
+  return apiFetch(`/preview-strip/${camera}?${params}`, options);
 }
 
 /**
@@ -119,14 +119,14 @@ export function eventSnapshotUrl(eventId) {
  *
  * TODO: add unit tests verifying bucket shape matches DensityResponse schema.
  */
-export async function fetchDensity(camera, startTs, endTs, bucketSec) {
+export async function fetchDensity(camera, startTs, endTs, bucketSec, options = {}) {
   const params = new URLSearchParams({
     camera,
     start: String(startTs),
     end: String(endTs),
   });
   if (bucketSec != null) params.set('bucket_sec', String(bucketSec));
-  return apiFetch(`/timeline/density?${params}`);
+  return apiFetch(`/timeline/density?${params}`, options);
 }
 
 /** GET /api/health */


### PR DESCRIPTION
## Summary

- Autoplay at ~60fps was firing the timeline + preview-strip useEffect on every frame with no debounce, flooding the backend with 3 parallel fetches per frame and exhausting the browser connection pool (`net::ERR_INSUFFICIENT_RESOURCES`)
- Add **300ms debounce + AbortController** to the timeline/preview-strip useEffect: the cleanup cancels the timer and aborts any in-flight request before the next range change fires a new one
- Apply the same **AbortController pattern** to the existing 100ms density debounce (timer was already there, abort was missing)
- Add `options` parameter to `fetchTimeline`, `fetchPreviewStrip`, `fetchDensity` in `api.js` so `AbortSignal` flows through to `fetch()`
- Remove the resolved TODO comment about debouncing during video playback

## Test plan

- [ ] 129 backend tests pass (`cd backend && pytest`)
- [ ] In DevTools Network tab during autoplay: confirm timeline/preview-strip requests fire at most once per 300ms, not 60× per second
- [ ] Cancelled requests show as `(canceled)` in Network tab — not queued failures
- [ ] No `net::ERR_INSUFFICIENT_RESOURCES` errors under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)