### PR TITLE
refactor(frontend): reticle-driven preview replaces hover scrub line

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,7 @@
  * v3 layout:
  *   - 100vh flex-column, no scroll
  *   - Single-camera: 2-column layout (VideoPlayer left, VerticalTimeline right)
- *   - Hover on VerticalTimeline shows preview overlay on VideoPlayer (hoverTs)
+ *   - Reticle position (cursorTs) drives preview overlay on VideoPlayer (75ms debounce)
  *   - Click on VerticalTimeline commits playback (handleSeek)
  *   - "Go to" datetime input in controls bar (single-camera mode only)
  *   - SplitView path unchanged
@@ -152,7 +152,6 @@ export default function App() {
   const [previewFrames, setPreviewFrames] = useState([]);
   const [cursorTs, setCursorTs] = useState(() => nowTs());
   const [rangeSec, setRangeSec] = useState(8 * 3600);
-  const [hoverTs, setHoverTs] = useState(null);
   const [playbackTarget, setPlaybackTarget] = useState(null);
   const [health, setHealth] = useState(null);
   const [error, setError] = useState(null);
@@ -173,6 +172,24 @@ export default function App() {
     const end = Math.min(cursor + rangeSec * RETICLE_FRACTION, nowTs() + 60);
     return { rangeStart: start, rangeEnd: end };
   }, [cursorTs, rangeSec]);
+
+  const [reticlePreviewUrl, setReticlePreviewUrl] = useState(null);
+
+  // Preview image for the VideoPlayer overlay, derived from the reticle
+  // position (cursorTs) with a short debounce so rapid autoplay / scroll
+  // does not hammer the preview endpoint.
+  // TODO: add frontend test verifying reticlePreviewUrl updates within 75ms
+  // of a cursorTs change and is null when selectedCamera is null.
+  useEffect(() => {
+    if (!selectedCamera || cursorTs == null) {
+      setReticlePreviewUrl(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setReticlePreviewUrl(`/api/preview/${selectedCamera}/${cursorTs}`);
+    }, 75);
+    return () => clearTimeout(timer);
+  }, [selectedCamera, cursorTs]);
 
   const [gotoValue, setGotoValue] = useState(() => toDatetimeLocal(nowTs()));
 
@@ -442,21 +459,6 @@ export default function App() {
     setCursorTs(newStart + newRange / 2);
   }, []);
 
-  // ─── Scrub handler: sets hover position for preview overlay ───
-  // cursorTs is NOT updated on hover — only clicking (handleSeek) recenters the view.
-  // TODO: verify markInteraction is called on all user input paths (scroll, click, keyboard).
-  const handleScrub = useCallback((ts) => {
-    lastInteractionRef.current = Date.now();
-    autoplayActiveRef.current = false;
-    const snapped = snapToCoverage(ts, timelineData?.segments);
-    setHoverTs(snapped);
-  }, [timelineData]);
-
-  // ─── Scrub end: clear hover ───
-  const handleScrubEnd = useCallback(() => {
-    setHoverTs(null);
-  }, []);
-
   // ─── Pan: shift cursorTs by deltaSec, clamping at nowTs() ───
   const handlePan = useCallback((deltaSec) => {
     lastInteractionRef.current = Date.now();
@@ -478,7 +480,6 @@ export default function App() {
       if (!selectedCamera) return;
       lastInteractionRef.current = Date.now();
       autoplayActiveRef.current = false;
-      setHoverTs(null);
       setCursorTs(ts);
       setActiveEventSnapshot(null);
 
@@ -540,7 +541,6 @@ export default function App() {
     setSelectedCamera(name);
     const cam = cameras.find(c => c.name === name);
     setCursorTs(cam?.latest_ts ?? nowTs());
-    setHoverTs(null);
     setPlaybackTarget(null);
     setTimelineData(null);
     setDensityData(null);
@@ -641,12 +641,6 @@ export default function App() {
 
     // setCursorTs(target.start_ts) above recenters the derived range automatically
   }, [navEvents, cursorTs, selectedCamera]);
-
-  // ─── Derive scrub preview URL ───
-  const activePreviewUrl =
-    hoverTs != null && selectedCamera
-      ? `/api/preview/${selectedCamera}/${hoverTs}`
-      : null;
 
   // ─── Derive autoplayState from refs at render time ───
   // Refs don't trigger renders, but cursorTs updating ~60fps during autoplay means
@@ -907,7 +901,7 @@ export default function App() {
                 camera={selectedCamera}
                 onTimeUpdate={handlePlaybackTimeUpdate}
                 onSegmentAdvance={handleSegmentAdvance}
-                scrubPreviewUrl={activePreviewUrl}
+                scrubPreviewUrl={reticlePreviewUrl}
                 isMobile={isMobile}
                 eventSnapshot={activeEventSnapshot}
                 onSeek={handleSeek}
@@ -956,8 +950,6 @@ export default function App() {
                 densityData={densityData}
                 activeLabels={activeLabels}
                 cursorTs={cursorTs}
-                onScrub={handleScrub}
-                onScrubEnd={handleScrubEnd}
                 onSeek={handleSeek}
                 onPan={handlePan}
                 onZoomChange={handleZoomChange}

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -138,8 +138,6 @@ export default function VerticalTimeline({
   activeLabels = null,
   cursorTs,
   autoplayState = 'idle',
-  onScrub,
-  onScrubEnd,
   onSeek,
   onPan,
   onZoomChange,
@@ -159,7 +157,6 @@ export default function VerticalTimeline({
   const drawCanvasRef = useRef(null);         // always points to latest draw fn
 
   const [dims, setDims] = useState({ w: 215, h: 600 });
-  const [hoverY, setHoverY] = useState(null);
 
   const debouncedPreviewRequest = useDebounce(
     (ts) => { if (onPreviewRequest) onPreviewRequest(ts); },
@@ -464,18 +461,7 @@ export default function VerticalTimeline({
       }
     }
 
-    // 9. Hover line (yellow, only when mouse is over canvas)
-    if (hoverY !== null) {
-      ctx.strokeStyle = 'rgba(255,220,80,0.85)';
-      ctx.lineWidth = 1;
-      ctx.setLineDash([]);
-      ctx.beginPath();
-      ctx.moveTo(barStart, hoverY);
-      ctx.lineTo(barEnd, hoverY);
-      ctx.stroke();
-    }
-
-    // 10. Reticle at fixed Y = h * RETICLE_FRACTION
+    // 9. Reticle at fixed Y = h * RETICLE_FRACTION
     // The reticle Y is a constant — it never moves. cursorTs always maps here
     // by construction (rangeStart/rangeEnd are derived from cursorTs in App.jsx).
     const displayTs = displayCursorRef.current;
@@ -529,7 +515,7 @@ export default function VerticalTimeline({
       ctx.fillStyle = 'rgba(160, 210, 240, 0.95)';
       ctx.fillText(label, badgeCx, reticleY);
     }
-  }, [dims, startTs, endTs, gaps, events, densityData, activeLabels, hoverY, autoplayState, tsToY]);
+  }, [dims, startTs, endTs, gaps, events, densityData, activeLabels, autoplayState, tsToY]);
   // Note: cursorTs is NOT a dep — read from displayCursorRef at draw time.
 
   // Keep drawCanvasRef pointing to the latest version of drawCanvas.
@@ -609,22 +595,16 @@ export default function VerticalTimeline({
   const handleMouseDown = useCallback(
     (e) => {
       isDragging.current = true;
-      const ts = getTs(e);
-      if (ts != null && onScrub) onScrub(ts);
     },
-    [getTs, onScrub]
+    []
   );
 
   const handleMouseMove = useCallback(
     (e) => {
-      const rect = canvasRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      setHoverY(e.clientY - rect.top);
       const ts = getTs(e);
-      if (ts != null && onScrub) onScrub(ts);
       if (ts != null) debouncedPreviewRequest(ts);
     },
-    [getTs, onScrub, debouncedPreviewRequest]
+    [getTs, debouncedPreviewRequest]
   );
 
   // Click = recenter with 250ms ease-out animation.
@@ -672,9 +652,7 @@ export default function VerticalTimeline({
 
   const handleMouseLeave = useCallback(() => {
     isDragging.current = false;
-    setHoverY(null);
-    if (onScrubEnd) onScrubEnd();
-  }, [onScrubEnd]);
+  }, []);
 
   return (
     <div

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -457,7 +457,7 @@ export default function VideoPlayer({
   }, []);
 
   const hasTarget = playbackTarget != null;
-  const showOverlay = scrubPreviewUrl != null && eventSnapshot == null;
+  const showOverlay = scrubPreviewUrl != null && !isPlaying && eventSnapshot == null;
   const showPlaceholder = !hasTarget && !showOverlay && !eventSnapshot;
 
   return (


### PR DESCRIPTION
## Summary

- Removes yellow hover/scrub line from VerticalTimeline
- Removes hoverTs state, handleScrub, handleScrubEnd from App.jsx
- Preview overlay on VideoPlayer now driven by cursorTs (75ms debounce)
- VideoPlayer overlay hidden while video is playing; shows reticle preview when paused or idle
- Breaking: VerticalTimeline no longer accepts onScrub / onScrubEnd props; all callers updated in this PR
- No backend changes; all pytest tests pass unchanged

## Test plan

- [ ] Hover over VerticalTimeline — no yellow line appears
- [ ] Preview overlay on VideoPlayer shows/updates as reticle moves (autoplay, keyboard nav, click)
- [ ] Overlay is hidden while video is actively playing
- [ ] Overlay reappears after video pauses/ends
- [ ] Camera switch clears preview (overlay goes dark until new cursorTs debounce fires)
- [ ] `cd backend && pytest` — 129 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)