### PR TITLE
fix(frontend): enforce event signal dominance and navigation reliability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -668,6 +668,95 @@ Do not flatten any of these to plain functions or remove `camera` from
 
 -----
 
+## Event rendering invariants
+
+These rules encode hard-won decisions about event visibility. Do not
+relax them without a documented reason.
+
+### navEvents must preserve full event objects
+
+navEvents is always a sorted array of full event objects. It must never
+be mapped to timestamps or any other partial representation. The full
+object is required by:
+- navigateEvent (has_snapshot, label, score, start_ts)
+- fetchPlaybackTarget (start_ts)
+- activeEventSnapshot (url, label, score, ts)
+
+The timestamp fallback chain (start_ts ?? start_time ?? timestamp)
+belongs only in code that reads individual event fields, never in
+navEvents construction.
+
+### Event timestamp fallback is mandatory in all consumers
+
+Any code that reads an event timestamp must use:
+  evt.start_ts ?? evt.start_time ?? evt.timestamp
+
+This applies to:
+- rendering (tsToY calls)
+- navigation (navigateEvent targetTs derivation)
+- preview targeting
+
+Do not assume start_ts exists. Missing fallback handling will cause
+silent failures where events render correctly but cannot be navigated
+to — the worst class of bug: invisible and intermittent.
+
+### EVENT_COLORS.default must be statically defined
+
+EVENT_COLORS must always include a default key in the object literal
+itself. It must not be added conditionally or at call sites. Any event
+label not in EVENT_COLORS falls back to this color. If default is
+missing, unknown labels produce invisible (undefined color) markers
+with no console error.
+
+### Event markers are visually dominant
+
+Event markers must always outrank ticks, hairlines, and background
+structure in visual weight. Current enforcement:
+- lineWidth = 2 (not 1)
+- opacity: 1.0 within 60px of reticle, 0.75 beyond
+- draw order: events drawn after ticks (Step 7 after Step 6)
+- marker span: 10%–90% of bar zone width
+
+If you find yourself reducing event opacity or lineWidth for aesthetic
+reasons, reconsider — events are the primary signal, not decoration.
+
+### Events render independently of other system state
+
+Event marker rendering must never be gated on:
+- densityData availability
+- preview generation state
+- autoplay state
+- any other derived data layer
+
+If events exist and fall within the visible range, they render. Period.
+
+### Silent rendering failures are always logged
+
+If events.length > 0 but renderedEventCount === 0 after the Step 7
+loop, a console.warn must fire. This guard is permanent infrastructure,
+not a temporary debug log. It catches coordinate system bugs, wiring
+errors, and filter regressions before they reach users.
+
+### Prev/Next navigation is first-class UI
+
+The Prev/Next block renders whenever navEvents.length > 0. It must
+never be hidden by multiMode, screen size, or layout constraints.
+flexShrink: 0 and whiteSpace: nowrap must be applied to prevent it
+from being squeezed out of the controls bar.
+
+### Navigation stops autoplay before moving the cursor
+
+In navigateEvent, the order is always:
+1. lastInteractionRef.current = Date.now()
+2. autoplayActiveRef.current = false
+3. setCursorTs(targetTs)  ← derived via fallback chain
+
+Autoplay must be cancelled before the cursor moves. Any reordering
+of these three lines will cause the autoplay RAF loop to fight the
+navigation jump.
+
+-----
+
 ## Workflow: Claude Chat -> Claude Code
 
 This project uses a two-mode AI workflow to keep changes fast, safe, and reviewable.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -655,9 +655,10 @@ export default function App() {
 
     if (!target) return;
 
-    setCursorTs(target.start_ts);
+    const targetTs = target.start_ts ?? target.start_time ?? target.timestamp;
+    setCursorTs(targetTs);
     try {
-      const playTarget = await fetchPlaybackTarget(selectedCamera, target.start_ts);
+      const playTarget = await fetchPlaybackTarget(selectedCamera, targetTs);
       console.log('[APP] setPlaybackTarget from event navigation', playTarget);
       setPlaybackTarget(playTarget);
     } catch {}
@@ -817,9 +818,9 @@ export default function App() {
 
           {/* Row 3: Event nav + autoplay + zoom presets (horizontal scroll, no goto) */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexWrap: 'nowrap', overflowX: 'auto' }}>
-            {!multiMode && navEvents.length > 0 && (
+            {navEvents.length > 0 && (
               <>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 6, background: 'rgba(255,255,255,0.04)', border: '1px solid #333', borderRadius: 6, padding: '6px 10px', fontFamily: 'monospace', fontSize: 13, fontWeight: 700, color: '#e0e0e0', flexShrink: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 6, background: 'rgba(255,255,255,0.04)', border: '1px solid #333', borderRadius: 6, padding: '6px 10px', fontFamily: 'monospace', fontSize: 13, fontWeight: 700, color: '#e0e0e0', flexShrink: 0, whiteSpace: 'nowrap' }}>
                   <button onClick={() => navigateEvent('prev')} style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: 14, padding: 0, fontFamily: 'monospace' }}>◀</button>
                   <span>EVENT {currentEventIndex != null ? currentEventIndex + 1 : '—'} / {navEvents.length}{importantOnly && ' ⚡'}</span>
                   <button onClick={() => navigateEvent('next')} style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: 14, padding: 0, fontFamily: 'monospace' }}>▶</button>
@@ -880,7 +881,7 @@ export default function App() {
           <div style={{ flex: 1 }} />
 
           {/* 3. Event nav + ⚡ */}
-          {!multiMode && navEvents.length > 0 && (
+          {navEvents.length > 0 && (
             <>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, background: 'rgba(255,255,255,0.04)', border: '1px solid #333', borderRadius: 6, padding: '4px 12px', fontFamily: 'monospace', fontSize: 13, fontWeight: 700, color: '#e0e0e0', flexShrink: 0, whiteSpace: 'nowrap' }}>
                 <button onClick={() => navigateEvent('prev')} style={{ background: 'none', border: 'none', color: '#aaa', cursor: 'pointer', fontSize: 14, padding: 0, fontFamily: 'monospace' }} onMouseEnter={e => e.target.style.color = '#4dd0e1'} onMouseLeave={e => e.target.style.color = '#aaa'} title="Previous event">◀</button>

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -97,7 +97,7 @@ const EVENT_COLORS = {
   car: '#2196F3',
   dog: '#FF9800',
   cat: '#9C27B0',
-  default: '#607D8B',
+  default: '#ffcc00',
 };
 
 /** Return the ZOOM_STOPS index whose value is nearest to the given range. */
@@ -407,12 +407,12 @@ export default function VerticalTimeline({
     // or wiring bug — do not suppress them here.
     //
     // TODO: extract _labelCollisionFilter(events, reticleY, tsToY) for unit testing.
-    const tickBarStart = barStart + barW * 0.2;
-    const tickBarEnd = barStart + barW * 0.8;
+    const tickBarStart = barStart + barW * 0.1;
+    const tickBarEnd   = barStart + barW * 0.9;
     const readingZoneEvents = [];
 
     let renderedEventCount = 0;
-    ctx.lineWidth = 1;
+    ctx.lineWidth = 2;
     ctx.setLineDash([]);
     for (const evt of events) {
       // Timestamp field guard: Frigate events use start_ts in the local
@@ -423,7 +423,7 @@ export default function VerticalTimeline({
       if (ts == null) continue;
 
       const y = tsToY(ts);
-      if (y < -2 || y > h + 2) continue;
+      if (y < -10 || y > h + 10) continue;
 
       renderedEventCount++;
       const distFromReticle = Math.abs(y - reticleY);
@@ -436,7 +436,7 @@ export default function VerticalTimeline({
         console.warn('[VerticalTimeline] Unknown event label:', evt.label);
       }
 
-      ctx.globalAlpha = distFromReticle <= 40 ? 0.9 : 0.6;
+      ctx.globalAlpha = distFromReticle <= 60 ? 1.0 : 0.75;
       ctx.strokeStyle = color;
       ctx.beginPath();
       ctx.moveTo(tickBarStart, y);
@@ -450,13 +450,12 @@ export default function VerticalTimeline({
     ctx.globalAlpha = 1.0;
 
     if (events.length > 0 && renderedEventCount === 0) {
-      console.warn('[VerticalTimeline] Events present but no markers rendered', {
+      console.warn('[VerticalTimeline] Events present but not visible', {
         eventCount: events.length,
         startTs,
         endTs,
         minEventTs: Math.min(...events.map(e => e.start_ts ?? e.start_time ?? 0)),
         maxEventTs: Math.max(...events.map(e => e.start_ts ?? e.start_time ?? 0)),
-        sampleEvent: events[0],
       });
     }
 


### PR DESCRIPTION
## Summary
- Event markers made visually dominant (lineWidth 2, opacity 0.75/1.0)
- Marker span extended to 10%-90% of bar zone width
- EVENT_COLORS.default statically defined as '#ffcc00' in object literal
- Event rendering guaranteed independent of density/preview/autoplay state
- Silent failure guard verified and kept as permanent infrastructure
- Proximity labels use existing readingZoneEvents system (no duplicate pass)
- navEvents preserves full event objects throughout
- navigateEvent derives targetTs via fallback chain (start_ts ?? start_time ?? timestamp)
- Prev/Next always visible when events exist, flexShrink:0 applied
- Navigation cancels autoplay before cursor update, strict order enforced
- Viewport guard extended to ±10px to prevent edge flicker
- CLAUDE.md updated: "Event rendering invariants" section added after "Conventions" section, including timestamp fallback mandate and EVENT_COLORS.default requirement
- No coordinate math changes, no backend changes

## Test plan
- [ ] Event markers clearly visible at all zoom levels, visually dominate ticks/hairlines
- [ ] Near reticle: event becomes fully opaque, proximity label appears (no duplicates)
- [ ] No events: Prev/Next block hidden cleanly
- [ ] Clicking Next jumps to next event using fallback chain; autoplay stops before cursor moves
- [ ] If events exist but none render → console.warn fires
- [ ] Unknown event label renders in '#ffcc00' (not invisible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)