### PR TITLE
fix(frontend): add willReadFrequently to VerticalTimeline canvas context

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -226,7 +226,11 @@ export default function VerticalTimeline({
     canvas.width = w * dpr;
     canvas.height = h * dpr;
 
-    const ctx = canvas.getContext('2d');
+    // willReadFrequently: true — required because drawReticleOnly uses
+    // getImageData/putImageData on every cursorTs change (~60fps during autoplay).
+    // Without this flag the browser emits a performance warning and may
+    // GPU-round-trip on every readback.
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
     ctx.scale(dpr, dpr);
 
     const barStart = LABEL_WIDTH + 1;
@@ -644,7 +648,11 @@ export default function VerticalTimeline({
       return;
     }
 
-    const ctx = canvas.getContext('2d');
+    // willReadFrequently: true — required because drawReticleOnly uses
+    // getImageData/putImageData on every cursorTs change (~60fps during autoplay).
+    // Without this flag the browser emits a performance warning and may
+    // GPU-round-trip on every readback.
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
     // putImageData writes at physical pixel coords — reset transform first.
     ctx.setTransform(1, 0, 0, 1, 0, 0);


### PR DESCRIPTION
## Summary

- Adds `{ willReadFrequently: true }` to both `canvas.getContext('2d')` calls in `VerticalTimeline.jsx`
- Eliminates the browser Canvas2D performance warning about multiple `getImageData` readbacks
- Avoids GPU round-trips on the `getImageData`/`putImageData` snapshot/restore path used by `drawReticleOnly` (~60fps during autoplay)

## Why

`drawReticleOnly` saves a pre-reticle canvas snapshot via `getImageData` and restores it via `putImageData` on every `cursorTs` change. Without `willReadFrequently: true`, the browser keeps the canvas in GPU memory and must round-trip to CPU on every read, both degrading performance and emitting a console warning.

## Scope

Only `VerticalTimeline.jsx` is changed. `Timeline.jsx` and `VideoPlayer.jsx` do not use `getImageData` and are left unchanged.

## Tests

No frontend canvas test harness exists. The fix is a one-attribute addition with no behavioral change; the comment added above each `getContext` call documents the reason for the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)