### PR TITLE
fix(frontend): deduplicate unknown event label warnings + add bird to EVENT_COLORS

### DIFF
--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -45,6 +45,7 @@ const EVENT_COLORS = {
   car: '#2196F3',
   dog: '#FF9800',
   cat: '#9C27B0',
+  bird: '#8BC34A',
   default: '#607D8B',
 };
 

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -97,6 +97,7 @@ const EVENT_COLORS = {
   car: '#2196F3',
   dog: '#FF9800',
   cat: '#9C27B0',
+  bird: '#8BC34A',
   default: '#ffcc00',
 };
 
@@ -425,6 +426,9 @@ export default function VerticalTimeline({
     const readingZoneEvents = [];
 
     let renderedEventCount = 0;
+    // TODO: test warnedLabels dedup — unknown label warns exactly once per
+    // drawCanvas call regardless of how many events share that label
+    const warnedLabels = new Set();
     ctx.lineWidth = 2;
     ctx.setLineDash([]);
     for (const evt of events) {
@@ -442,11 +446,12 @@ export default function VerticalTimeline({
       const distFromReticle = Math.abs(y - reticleY);
       const color = EVENT_COLORS[evt.label] || EVENT_COLORS.default;
 
-      if (!EVENT_COLORS[evt.label]) {
+      if (!EVENT_COLORS[evt.label] && !warnedLabels.has(evt.label)) {
         // Log unknown labels — helps catch label casing mismatches
-        // (e.g. "person:face" or "Person"). If this fires on every render,
-        // add the label to EVENT_COLORS instead of silencing the warn.
+        // (e.g. "person:face" or "Person"). Fires once per unknown label
+        // per drawCanvas call to avoid console spam at 60fps.
         console.warn('[VerticalTimeline] Unknown event label:', evt.label);
+        warnedLabels.add(evt.label);
       }
 
       ctx.globalAlpha = distFromReticle <= 60 ? 1.0 : 0.75;


### PR DESCRIPTION
## Summary

- **Issue 1 fix:** Unknown event label warnings now deduplicate using a `warnedLabels` Set created once per `drawCanvas` call. Previously each unknown label fired `console.warn` for every matching event on every frame — 18 bird events × 60fps = ~1,080 warns/sec. Now fires once per unknown label per draw pass.
- Added `bird: '#8BC34A'` to `EVENT_COLORS` in both `VerticalTimeline.jsx` and `Timeline.jsx` so bird events render with a distinct yellow-green color instead of hitting the unknown-label warn path at all.
- Added TODO comment at the dedup site for future test coverage.

## Issue 2 (autoplay default)

No code change needed. The autoplay-off state is correct — it persisted from a previous session via `localStorage`. The cursor landing 8 days in the past is consistent with a stale `?ts=` URL param from a copied link, not a code bug.

## Test plan

- [ ] Open the app with 18+ bird events visible — confirm `[VerticalTimeline] Unknown event label: bird` no longer appears (bird now has a color entry)
- [ ] Introduce a novel label (e.g. rename one event label in dev) — confirm warn fires exactly once per render frame, not N times
- [ ] Bird events render in yellow-green (`#8BC34A`) on both vertical and horizontal timelines
- [ ] All other event colors unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)