### PR TITLE
feat(frontend): video playback during autoplay + auto-dismiss event snapshot overlay

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -263,6 +263,10 @@ export default function App() {
   // Event snapshot state (from prev/next navigation)
   const [activeEventSnapshot, setActiveEventSnapshot] = useState(null);
 
+  // autoplayRunning mirrors autoplayActiveRef for React-land consumers (VideoPlayer).
+  // Set inside the RAF tick on the false→true and true→false transitions only.
+  const [autoplayRunning, setAutoplayRunning] = useState(false);
+
   // Refs that track the latest cursorTs / playbackTarget without being deps
   // of handleSegmentAdvance — avoids recreating the callback (and therefore
   // VideoPlayer's onSegmentAdvance prop) on every timeupdate event.
@@ -283,6 +287,9 @@ export default function App() {
   const autoplayStartRef = useRef(Date.now());
   const autoplayEnabledRef = useRef(true);   // synced with autoplayEnabled state below
   const autoplayRafRef = useRef(null);
+  // videoPlayingRef: true when HLS video is actively playing — RAF skips cursor
+  // advance so the video drives cursorTs via onTimeUpdate instead.
+  const videoPlayingRef = useRef(false);
   // nearEventCacheRef: sorted filteredEvents + next upcoming event ahead of cursor.
   // Updated by useEffect on filteredEvents (infrequent); re-searched inside setCursorTs.
   // TODO: verify pullFactor never drops below 0.2 and cache invalidates on filteredEvents change.
@@ -310,6 +317,7 @@ export default function App() {
         if (!autoplayActiveRef.current) {
           autoplayActiveRef.current = true;
           autoplayStartRef.current = now;
+          setAutoplayRunning(true); // notify React — triggers video start via useEffect
         }
 
         // Ease-in over 300ms: advance rate ramps 0→1x
@@ -317,31 +325,36 @@ export default function App() {
         const easeFactor = easeMs / 300;
         const baseAdvanceSec = (1 / 60) * easeFactor;
 
-        setCursorTs(prev => {
-          let advanceSec = baseAdvanceSec;
+        // Skip cursor advance while video is playing — video drives cursorTs
+        // via onTimeUpdate → handlePlaybackTimeUpdate → setCursorTs.
+        if (!videoPlayingRef.current) {
+          setCursorTs(prev => {
+            let advanceSec = baseAdvanceSec;
 
-          // Magnetization: decelerate near upcoming events (never below 20% rate).
-          // Cache miss: if cursor passed the cached event, find the next one.
-          // TODO: verify pullFactor clamp — distSec→0 gives pullFactor=0.2, distSec≥10 gives 1.0.
-          let nextEvent = nearEventCacheRef.current.event;
-          if (nextEvent && nextEvent.start_ts <= prev) {
-            // Cursor has passed the cached event — search forward in sorted list.
-            nextEvent = nearEventCacheRef.current.sorted.find(e => e.start_ts > prev) ?? null;
-            nearEventCacheRef.current = { ...nearEventCacheRef.current, event: nextEvent };
-          }
-          if (nextEvent) {
-            const distSec = nextEvent.start_ts - prev;
-            if (distSec > 0 && distSec < 10) {
-              const pullFactor = 0.2 + 0.8 * (distSec / 10);
-              advanceSec *= pullFactor;
+            // Magnetization: decelerate near upcoming events (never below 20% rate).
+            // Cache miss: if cursor passed the cached event, find the next one.
+            // TODO: verify pullFactor clamp — distSec→0 gives pullFactor=0.2, distSec≥10 gives 1.0.
+            let nextEvent = nearEventCacheRef.current.event;
+            if (nextEvent && nextEvent.start_ts <= prev) {
+              // Cursor has passed the cached event — search forward in sorted list.
+              nextEvent = nearEventCacheRef.current.sorted.find(e => e.start_ts > prev) ?? null;
+              nearEventCacheRef.current = { ...nearEventCacheRef.current, event: nextEvent };
             }
-          }
+            if (nextEvent) {
+              const distSec = nextEvent.start_ts - prev;
+              if (distSec > 0 && distSec < 10) {
+                const pullFactor = 0.2 + 0.8 * (distSec / 10);
+                advanceSec *= pullFactor;
+              }
+            }
 
-          return Math.min(prev + advanceSec, nowTs());
-        });
+            return Math.min(prev + advanceSec, nowTs());
+          });
+        }
       } else {
         if (autoplayActiveRef.current) {
           autoplayActiveRef.current = false;
+          setAutoplayRunning(false); // notify React — triggers video pause via prop
         }
       }
 
@@ -575,6 +588,46 @@ export default function App() {
   const handlePlaybackStart = useCallback(() => {
     setActiveEventSnapshot(null);
   }, []);
+
+  // ─── Auto-dismiss event snapshot when cursor moves >30s away from it ───
+  // Prevents the snapshot overlay from pinning while autoplay or scrolling
+  // advances the cursor beyond the event that triggered the snapshot.
+  // TODO: test snapshot dismiss: activeEventSnapshot clears when cursorTs moves
+  // >30s from snapshot.ts
+  useEffect(() => {
+    if (!activeEventSnapshot) return;
+    if (Math.abs(cursorTs - activeEventSnapshot.ts) > 30) {
+      setActiveEventSnapshot(null);
+    }
+  }, [cursorTs, activeEventSnapshot]);
+
+  // ─── Start video playback when autoplay activates ───
+  // Uses a separate fetch path (not handleSeek) so interaction refs are not
+  // reset — resetting lastInteractionRef inside handleSeek would immediately
+  // deactivate autoplay, creating an activation loop.
+  // TODO: test autoplay→video start: after AUTOPLAY_DELAY_MS idle, a
+  // fetchPlaybackTarget call is made with cursorTsRef.current
+  const startAutoplayVideo = useCallback(async () => {
+    if (!selectedCamera) return;
+    seekRequestIdRef.current++;
+    const myId = seekRequestIdRef.current;
+    const camera = selectedCamera;
+    try {
+      const target = await fetchPlaybackTarget(camera, cursorTsRef.current);
+      if (myId !== seekRequestIdRef.current) return; // stale — another seek superseded
+      console.log('[APP] setPlaybackTarget from autoplay start', target);
+      setPlaybackTarget(target);
+      setError(null);
+    } catch (err) {
+      if (myId !== seekRequestIdRef.current) return;
+      setError(`Autoplay failed: ${err.message}`);
+    }
+  }, [selectedCamera]);
+
+  useEffect(() => {
+    if (!autoplayRunning) return;
+    startAutoplayVideo();
+  }, [autoplayRunning, startAutoplayVideo]);
 
   // ─── Preload hint: communicated from VerticalTimeline during slow scrub ───
   const handlePreloadHint = useCallback((ts) => {
@@ -1021,6 +1074,8 @@ export default function App() {
                 onSeek={handleSeek}
                 onPlaybackStart={handlePlaybackStart}
                 preloadTargetTs={preloadTargetTs}
+                autoplayActive={autoplayRunning}
+                onPlaybackStateChange={(playing) => { videoPlayingRef.current = playing; }}
               />
             </div>
 

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -58,6 +58,8 @@ export default function VideoPlayer({
   onSeek = null,
   onPlaybackStart = null,
   preloadTargetTs = null,
+  autoplayActive = false,
+  onPlaybackStateChange = null,
 }) {
   const videoRef = useRef(null);
   const preloadRef = useRef(null);
@@ -488,6 +490,16 @@ export default function VideoPlayer({
     video.muted = isMuted;
   }, [isMuted]);
 
+  // Pause video when autoplay deactivates (user interacted).
+  // On initial mount autoplayActive is false and video is paused — no-op.
+  useEffect(() => {
+    if (autoplayActive) return;
+    const video = videoRef.current;
+    if (video && !video.paused) {
+      video.pause();
+    }
+  }, [autoplayActive]);
+
   const handleToggleMute = useCallback(() => {
     setIsMuted(prev => {
       const next = !prev;
@@ -637,8 +649,12 @@ export default function VideoPlayer({
           onPlay={() => {
             setIsPlaying(true);
             if (onPlaybackStart) onPlaybackStart();
+            if (onPlaybackStateChange) onPlaybackStateChange(true);
           }}
-          onPause={() => setIsPlaying(false)}
+          onPause={() => {
+            setIsPlaying(false);
+            if (onPlaybackStateChange) onPlaybackStateChange(false);
+          }}
           playsInline
         />
 


### PR DESCRIPTION
## Summary

### Issue 1 — event snapshot auto-dismiss
- Added `useEffect` watching `cursorTs` + `activeEventSnapshot`. When the cursor moves more than 30 seconds from the snapshot's `ts`, `activeEventSnapshot` is cleared and the scrub preview resumes. Dismissal was previously only triggered by timeline click (`handleSeek`) or video play start (`handlePlaybackStart`).

### Issue 2 — video plays during autoplay
Four cooperating pieces:

**`autoplayRunning` state** — mirrors `autoplayActiveRef` for React consumers. Set to `true`/`false` on the exact transition frames in the RAF tick (not every frame) so React re-renders are minimal.

**`videoPlayingRef`** — set by `onPlaybackStateChange` callback from VideoPlayer. When `true`, the RAF tick skips the `setCursorTs` advance entirely; the video's `onTimeUpdate` drives `cursorTs` instead, preventing the RAF from fighting the video clock.

**`startAutoplayVideo`** — separate from `handleSeek`. Fetches a `PlaybackTarget` and sets it without touching `lastInteractionRef` or `autoplayActiveRef`. Calling `handleSeek` directly would reset `lastInteractionRef = Date.now()`, making `idleMs = 0` in the next tick and immediately deactivating autoplay — creating a 1500ms re-activation loop.

**VideoPlayer `autoplayActive` prop** — when it transitions from `true → false` (user interacted, autoplay stopped), a `useEffect` calls `video.pause()` immediately. On initial mount the video is already paused so this is a no-op.

## Invariants preserved
- `cursorTs` is single source of truth — video follows cursor during scrub; cursor follows video only while HLS is actively playing
- `handleSeek` remains the only explicit user-initiated seek path
- Autoplay RAF loop remains stable (no new deps)

## Test plan
- [ ] After 1.5s idle, video begins playing from cursor position
- [ ] Timeline reticle advances with video (onTimeUpdate feeds back into cursorTs)
- [ ] Scrolling the timeline pauses the video and resumes scrub preview
- [ ] Navigating to event via Prev/Next shows snapshot; scrolling or waiting for autoplay to advance >30s dismisses it and restores scrub preview
- [ ] Camera switch while autoplay is active: video stops, new camera starts fresh
- [ ] No activation loop: autoplay does not immediately deactivate after starting video

🤖 Generated with [Claude Code](https://claude.com/claude-code)