### PR TITLE
fix(frontend): enable vertical touch panning on mobile VerticalTimeline

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -1073,26 +1073,45 @@ export default function VerticalTimeline({
           touchStartRef.current = { x: touch.clientX, y: touch.clientY };
           handleMouseDown({ clientX: touch.clientX, clientY: touch.clientY });
         }}
+        // TODO: test touch pan -- vertical swipe calls onPan with
+        // zoom-scaled delta; inertial decay fires on touchEnd
         onTouchMove={(e) => {
           e.preventDefault();
           const touch = e.touches[0];
           const dx = touch.clientX - (touchStartRef.current?.x ?? touch.clientX);
           const dy = touch.clientY - (touchStartRef.current?.y ?? touch.clientY);
-          const isHorizontalSwipe = Math.abs(dx) > Math.abs(dy) * 1.5 && Math.abs(dx) > 10;
 
-          if (isHorizontalSwipe && onPan) {
-            // Horizontal swipe → pan: map swipe distance to time delta
-            const fraction = -dx / dims.w * 0.5;
-            onPan(range * fraction);
+          if (Math.abs(dy) > 5 && onPan) {
+            // Vertical swipe → pan (primary gesture for a vertical timeline).
+            // Cancel any in-flight decay so new input never stacks onto a glide.
+            if (scrollRafRef.current) {
+              cancelAnimationFrame(scrollRafRef.current);
+              scrollRafRef.current = null;
+            }
+            // Same zoom-aware sensitivity as the wheel handler (K=0.22).
+            const K = 0.22;
+            const deltaSec = dy * secondsPerPixel * K;
+            scrollVelocityRef.current = deltaSec;
+            onPan(deltaSec);
+            // Continuous tracking: update origin so each move delta is relative
+            // to the previous position, not the original touch-start.
             touchStartRef.current = { x: touch.clientX, y: touch.clientY };
             return;
           }
 
+          // Horizontal swipe is a secondary/fallthrough gesture — ignored on a
+          // vertical timeline where dx panning would be confusing.
           handleMouseMove({ clientX: touch.clientX, clientY: touch.clientY });
         }}
         onTouchEnd={(e) => {
           e.preventDefault();
           const touch = e.changedTouches[0];
+          // Kick off inertial glide if the last touch move left non-trivial velocity.
+          const DEADZONE = secondsPerPixel * 0.008;
+          if (Math.abs(scrollVelocityRef.current) > DEADZONE) {
+            if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current);
+            scrollRafRef.current = requestAnimationFrame(decayScroll);
+          }
           handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
         }}
       />


### PR DESCRIPTION
## Summary

- **Root cause:** `onTouchMove` treated horizontal swipes as the pan gesture (`isHorizontalSwipe` branch called `onPan`). Vertical swipes — the natural gesture for a vertical timeline — fell through to `handleMouseMove`, which only tracks scrub velocity and fires preview requests, never calling `onPan`. Touch devices don't fire wheel events, so vertical panning was completely broken on mobile.
- **Fix:** Invert the axis logic. Vertical `dy > 5px` deadzone is now the primary pan path, using the same zoom-aware `K=0.22 * secondsPerPixel` sensitivity as `handleWheel`. `touchStartRef` is updated continuously so each event's delta is frame-relative (not one-shot from touch start). `onTouchEnd` fires `decayScroll` when `scrollVelocityRef` is non-trivial, giving inertial glide matching desktop wheel behavior.
- **Horizontal branch removed:** On a vertical timeline, horizontal swipe panning was confusing and incorrect — removed rather than kept as secondary.

## Invariants preserved

- Sensitivity scales with `secondsPerPixel` (zoomed in = slower/more precise)
- New input cancels existing decay (`cancelAnimationFrame` before accumulating)
- `cursorTs` only changes via `onPan`/`onSeek` — never directly
- No backend calls in interaction loop
- `touchAction: 'manipulation'` and `e.preventDefault()` unchanged

## Test plan

- No automated test coverage for touch interaction (no frontend test harness). TODO comment added above the touch handlers in `VerticalTimeline.jsx`.
- Manual verification: open on a mobile device or Chrome DevTools touch simulation, swipe up/down on the timeline — time should pan smoothly with inertial glide on release.

## Notes

This PR is on `feat/idle-preload-autoplay-state-machine` which contains other in-progress work. The touch fix itself is isolated to the `onTouchMove`/`onTouchEnd` handlers (lines 1076–1116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)