### PR TITLE
fix(frontend): prevent page scroll during mobile timeline touch panning

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1120,6 +1120,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     overflow: 'hidden',
+    overscrollBehavior: 'none',
     padding: '10px 14px 0',
     boxSizing: 'border-box',
   },

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -1051,13 +1051,14 @@ export default function VerticalTimeline({
         userSelect: 'none',
         display: 'flex',
         flexDirection: 'column',
+        touchAction: 'none',
       }}
     >
       {/* Canvas wrapper — relative-positioned so the badge is scoped to canvas height */}
       <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
       <canvas
         ref={canvasRef}
-        style={{ cursor: 'crosshair', display: 'block', width: '100%', height: '100%', touchAction: 'manipulation' }}
+        style={{ cursor: 'crosshair', display: 'block', width: '100%', height: '100%', touchAction: 'none' }}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
@@ -1069,14 +1070,18 @@ export default function VerticalTimeline({
             scrollRafRef.current = null;
           }
           e.preventDefault();
+          e.stopPropagation();
           const touch = e.touches[0];
           touchStartRef.current = { x: touch.clientX, y: touch.clientY };
           handleMouseDown({ clientX: touch.clientX, clientY: touch.clientY });
         }}
         // TODO: test touch pan -- vertical swipe calls onPan with
         // zoom-scaled delta; inertial decay fires on touchEnd
+        // TODO: test mobile touch isolation — vertical swipe on timeline
+        // must not cause page scroll or overscroll bounce
         onTouchMove={(e) => {
           e.preventDefault();
+          e.stopPropagation();
           const touch = e.touches[0];
           const dx = touch.clientX - (touchStartRef.current?.x ?? touch.clientX);
           const dy = touch.clientY - (touchStartRef.current?.y ?? touch.clientY);
@@ -1105,6 +1110,7 @@ export default function VerticalTimeline({
         }}
         onTouchEnd={(e) => {
           e.preventDefault();
+          e.stopPropagation();
           const touch = e.changedTouches[0];
           // Kick off inertial glide if the last touch move left non-trivial velocity.
           const DEADZONE = secondsPerPixel * 0.008;


### PR DESCRIPTION
## Summary
- `touchAction: 'none'` on both the canvas element and container div fully suppresses native browser pan/scroll/zoom on the timeline component (was `'manipulation'` which still allows browser panning)
- `e.stopPropagation()` added to all three touch handlers (onTouchStart, onTouchMove, onTouchEnd) to prevent events bubbling to parent containers
- `overscrollBehavior: 'none'` added to the top-level app container to suppress pull-to-refresh and elastic overscroll bounce on mobile (no effect on desktop since container already has `overflow: hidden`)

## Root causes fixed
1. `touchAction: 'manipulation'` on the canvas permitted browser-driven panning — replaced with `'none'` to hand full control to the JS handlers
2. Touch events bubbling past the canvas to parent containers triggered native page scroll — stopped with `stopPropagation()`

## Test plan
- [ ] Vertical swipe on timeline on mobile — timeline pans, page does not scroll
- [ ] Pull-to-refresh gesture on mobile — does not trigger
- [ ] Desktop mouse/wheel interaction unaffected
- [ ] Zoom slider and Prev/Next buttons still respond to touch/click normally
- [ ] TODO comment added for future automated test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)