### PR TITLE
fix(frontend): distinguish tap from pan on mobile to prevent timeline snapback

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -267,6 +267,7 @@ export default function VerticalTimeline({
   // lastPreloadTsRef prevents spam: hint only fires when |ts - last| > 2s.
   const scrubLastYRef = useRef(null);    // { y: number, time: number }
   const scrubVelocityRef = useRef(0);    // px/ms
+  const touchPannedRef = useRef(false);  // true if this touch gesture included a pan (dy > 5); gates tap-to-recenter
   const scrubIdleTimerRef = useRef(null);
   const lastPreloadTsRef = useRef(null); // spam suppression
 
@@ -1065,6 +1066,7 @@ export default function VerticalTimeline({
         onMouseLeave={handleMouseLeave}
         onTouchStart={(e) => {
           scrollVelocityRef.current = 0;
+          touchPannedRef.current = false;
           if (scrollRafRef.current) {
             cancelAnimationFrame(scrollRafRef.current);
             scrollRafRef.current = null;
@@ -1088,6 +1090,8 @@ export default function VerticalTimeline({
 
           if (Math.abs(dy) > 5 && onPan) {
             // Vertical swipe → pan (primary gesture for a vertical timeline).
+            // Mark this as a pan gesture so touchEnd skips click-to-recenter.
+            touchPannedRef.current = true;
             // Cancel any in-flight decay so new input never stacks onto a glide.
             if (scrollRafRef.current) {
               cancelAnimationFrame(scrollRafRef.current);
@@ -1108,17 +1112,26 @@ export default function VerticalTimeline({
           // vertical timeline where dx panning would be confusing.
           handleMouseMove({ clientX: touch.clientX, clientY: touch.clientY });
         }}
+        // TODO: test tap vs pan discrimination — tap triggers click-to-recenter
+        // animation; pan with dy > threshold skips recenter and fires inertial decay
         onTouchEnd={(e) => {
           e.preventDefault();
           e.stopPropagation();
           const touch = e.changedTouches[0];
-          // Kick off inertial glide if the last touch move left non-trivial velocity.
-          const DEADZONE = secondsPerPixel * 0.008;
-          if (Math.abs(scrollVelocityRef.current) > DEADZONE) {
-            if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current);
-            scrollRafRef.current = requestAnimationFrame(decayScroll);
+          if (touchPannedRef.current) {
+            // Pan gesture: kick off inertial glide and skip click-to-recenter.
+            const DEADZONE = secondsPerPixel * 0.008;
+            if (Math.abs(scrollVelocityRef.current) > DEADZONE) {
+              if (scrollRafRef.current) cancelAnimationFrame(scrollRafRef.current);
+              scrollRafRef.current = requestAnimationFrame(decayScroll);
+            }
+            isDragging.current = false;
+            scrubLastYRef.current = null;
+            scrubVelocityRef.current = 0;
+          } else {
+            // Tap gesture: delegate to handleMouseUp for click-to-recenter animation.
+            handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
           }
-          handleMouseUp({ clientX: touch.clientX, clientY: touch.clientY });
         }}
       />
 


### PR DESCRIPTION
## Summary

- `onTouchEnd` was unconditionally calling `handleMouseUp`, which runs the click-to-recenter 250ms ease-out animation
- During a pan gesture this fought the pan — on finger lift, the cursor snapped to the release position instead of continuing inertial decay
- Fix: add `touchPannedRef` (reset on `touchStart`, set in `onTouchMove` when the vertical pan branch fires with `dy > 5px`); `onTouchEnd` branches on this flag

## Behaviour after fix

| Gesture | `touchPannedRef` | `onTouchEnd` action |
|---------|-----------------|---------------------|
| Tap | `false` | calls `handleMouseUp` → click-to-recenter animation |
| Vertical swipe | `true` | skips `handleMouseUp`, fires inertial decay only |

## Invariants preserved

- Click/tap = recenter with 250ms ease-out (tap path unchanged)
- Pan = velocity inertial decay with `DAMPING=0.88`
- New input cancels existing decay (`cancelAnimationFrame` before accumulating)
- Sensitivity scales with `secondsPerPixel`
- `cursorTs` changed only via `onPan`/`onSeek`
- No backend calls in interaction loop

## Test plan

- [ ] Mobile: vertical swipe pans the timeline and lifts off smoothly with inertial decay — no cursor snap
- [ ] Mobile: tap on a point in the timeline recenters the cursor to that position with animation
- [ ] Desktop: no regression — wheel pans, click recenters (separate events, unaffected)
- [ ] TODO comment added above `onTouchEnd` for future test harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)