### PR TITLE
refactor(frontend): simplify reticle to plain line and transparent badge

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -249,7 +249,6 @@ export default function VerticalTimeline({
   // Visual layout props — controllable from Storybook
   backgroundColor    = null,           // overrides both label-zone and bar-zone backgrounds when set
   tickLabelXPct      = 93,             // 0-100: horizontal position of tick labels as % of LABEL_WIDTH
-  reticleBadgeBgAlpha = 0.55,          // 0-1: opacity of the reticle timestamp badge background
 }) {
   const canvasRef = useRef(null);
   const containerRef = useRef(null);
@@ -638,22 +637,8 @@ export default function VerticalTimeline({
     // by construction (rangeStart/rangeEnd are derived from cursorTs in App.jsx).
     const displayTs = displayCursorRef.current;
     if (displayTs != null) {
-      // Reticle glow — color and intensity respond to autoplayState:
-      //   'idle'             → base blue at 0.06 alpha
-      //   'advancing'        → blue pulsing 0.06→0.12 on 3s sine (drawn at current time)
-      //   'approaching_event'→ amber-red at 0.10 (distinct from density blue)
-      let glowStyle;
-      if (autoplayState === 'approaching_event') {
-        glowStyle = 'rgba(220, 80, 60, 0.10)';
-      } else if (autoplayState === 'advancing') {
-        const t = (performance.now() / 3000) * Math.PI * 2;
-        const alpha = (0.06 + 0.06 * (0.5 + 0.5 * Math.sin(t))).toFixed(3);
-        glowStyle = `rgba(60, 160, 220, ${alpha})`;
-      } else {
-        glowStyle = 'rgba(60, 160, 220, 0.06)';
-      }
-      ctx.fillStyle = glowStyle;
-      ctx.fillRect(barStart, reticleY - 20, barW, 40);
+      // TODO: test reticle rendering — single line + tick marks only,
+      // no glow band or filled rectangle behind reticle
 
       // Ruler: center line + 11 evenly-spaced tick marks
       ctx.strokeStyle = 'rgba(100, 180, 220, 0.6)';
@@ -738,19 +723,6 @@ export default function VerticalTimeline({
 
     const displayTs = displayCursorRef.current;
     if (displayTs != null) {
-      let glowStyle;
-      if (autoplayState === 'approaching_event') {
-        glowStyle = 'rgba(220, 80, 60, 0.10)';
-      } else if (autoplayState === 'advancing') {
-        const t = (performance.now() / 3000) * Math.PI * 2;
-        const alpha = (0.06 + 0.06 * (0.5 + 0.5 * Math.sin(t))).toFixed(3);
-        glowStyle = `rgba(60, 160, 220, ${alpha})`;
-      } else {
-        glowStyle = 'rgba(60, 160, 220, 0.06)';
-      }
-      ctx.fillStyle = glowStyle;
-      ctx.fillRect(barStart, reticleY - 20, barW, 40);
-
       // Ruler: center line + 11 evenly-spaced tick marks
       ctx.strokeStyle = 'rgba(100, 180, 220, 0.6)';
       ctx.lineWidth = 1;
@@ -770,7 +742,7 @@ export default function VerticalTimeline({
         ctx.stroke();
       }
     }
-  }, [dims, startTs, endTs, autoplayState]);
+  }, [dims, startTs, endTs]);
 
   useEffect(() => { drawReticleOnlyRef.current = drawReticleOnly; }, [drawReticleOnly]);
 
@@ -1103,10 +1075,9 @@ export default function VerticalTimeline({
             display: 'flex',
             alignItems: 'center',
             gap: 6,
-            background: `rgba(0, 0, 0, ${reticleBadgeBgAlpha})`,
+            background: 'transparent',
             borderRadius: 6,
             padding: '4px 10px',
-            backdropFilter: 'blur(4px)',
           }}>
             {/* AM/PM stack — 12h mode only */}
             {reticleParts.is12h && (

--- a/frontend/src/stories/VerticalTimeline.stories.jsx
+++ b/frontend/src/stories/VerticalTimeline.stories.jsx
@@ -16,7 +16,6 @@
  * Visual layout props:
  *   backgroundColor     — canvas background color (both zones)
  *   tickLabelXPct       — 0-100: horizontal position of tick labels (% of label zone width)
- *   reticleBadgeBgAlpha — 0-1: opacity of the reticle timestamp badge background
  *
  * Invariants preserved (CLAUDE.md):
  *  - cursorTs is the single source of truth; updated only by explicit user action
@@ -59,10 +58,6 @@ export default {
     tickLabelXPct: {
       control: { type: 'range', min: 0, max: 100, step: 1 },
       description: 'Horizontal position of tick time labels as a percentage of the label zone width (0 = left, 100 = right)',
-    },
-    reticleBadgeBgAlpha: {
-      control: { type: 'range', min: 0, max: 1, step: 0.01 },
-      description: 'Opacity of the reticle timestamp badge background (0 = transparent, 1 = opaque)',
     },
     // ── Font controls ─────────────────────────────────────────────────────
     fontFamily: {
@@ -189,7 +184,7 @@ function makeMockGaps(anchorTs, rangeSec) {
  */
 function InteractiveTimeline({
   timeFormat, isMobile, autoplayState,
-  backgroundColor, tickLabelXPct, reticleBadgeBgAlpha,
+  backgroundColor, tickLabelXPct,
   fontFamily, tickFontSize, tickFontWeight, tickFontStyle, tickColor,
   labelFontSize, labelFontWeight, labelFontStyle, secondsAccentColor,
 }) {
@@ -230,7 +225,6 @@ function InteractiveTimeline({
           isMobile={isMobile}
           backgroundColor={backgroundColor}
           tickLabelXPct={tickLabelXPct}
-          reticleBadgeBgAlpha={reticleBadgeBgAlpha}
           fontFamily={fontFamily}
           tickFontSize={tickFontSize}
           tickFontWeight={tickFontWeight}
@@ -296,7 +290,6 @@ const FONT_DEFAULTS = {
 const LAYOUT_DEFAULTS = {
   backgroundColor:     null,
   tickLabelXPct:       93,
-  reticleBadgeBgAlpha: 0.55,
 };
 
 export const Default = {


### PR DESCRIPTION
## Summary

- Remove the 40px glow band (`fillRect`) behind the reticle in both `drawCanvas()` and `drawReticleOnly()` — reticle is now a plain ruler line + tick marks only
- Remove `autoplayState` from `drawReticleOnly`'s `useCallback` dep array (no longer referenced)
- Make the reticle timestamp badge background fully transparent; remove `backdropFilter: blur(4px)` (no background = no blur needed)

## Test plan

- [ ] Verify the reticle renders as a clean horizontal line with tick marks and no background fill
- [ ] Verify the timestamp badge text floats over the timeline with no dark backing
- [ ] Verify autoplay advancing/approaching_event states no longer cause any visual change to the reticle band
- [ ] Verify scroll, pan, and navigation still function correctly

Note: no automated frontend test harness. A TODO comment is added near the reticle drawing block for future coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)