### PR TITLE
refactor(frontend): left-align tick labels and reticle badge on timeline

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -4,9 +4,10 @@
  * Time flows bottom (startTs) → top (endTs). Future is UP, past is DOWN.
  *
  * Horizontal zones (left to right):
- *   [0 … 58px]      — time tick labels (right-aligned, monospace 11px)
+ *   [0 … 58px]      — left label zone: event icons (right-aligned to LABEL_WIDTH-18)
  *   [58px]           — 1px separator line
- *   [59 … w-18px]    — bar zone: density gradient, detection ticks, event markers
+ *   [59 … w-18px]    — bar zone: density gradient, detection ticks, event markers,
+ *                      tick labels (left-aligned at LABEL_WIDTH+6)
  *   [w-18px … w]     — right edge (used by important-event diamond markers)
  *
  * Drawing order (bottom layer → top):
@@ -515,9 +516,9 @@ export default function VerticalTimeline({
       ctx.fillStyle = tickColor;
 
       ctx.globalAlpha = fadeFactor;   // fadeFactor is the sole opacity driver
-      ctx.textAlign = 'right';
+      ctx.textAlign = 'left';
       ctx.textBaseline = 'middle';
-      ctx.fillText(formatHHMM(t, timeFormat), (tickLabelXPct / 100) * LABEL_WIDTH, y);
+      ctx.fillText(formatHHMM(t, timeFormat), LABEL_WIDTH + 6, y);
       ctx.globalAlpha = 1.0;          // ALWAYS reset immediately
     }
 
@@ -1056,17 +1057,19 @@ export default function VerticalTimeline({
       />
 
       {/* Reticle timestamp badge — DOM overlay scoped to canvas wrapper, pointer-events:none */}
+      {/* TODO: test tick label and badge alignment — tick labels left-aligned
+          at LABEL_WIDTH + 6, badge left-aligned to match */}
       {reticleParts && (
         <div
           style={{
             position: 'absolute',
             top: `calc(${RETICLE_FRACTION * 100}% - 24px)`,
-            left: LABEL_WIDTH + 2,
+            left: LABEL_WIDTH - 4,
             right: EVENT_WIDTH + 2,
             height: 48,
             display: 'flex',
             alignItems: 'center',
-            justifyContent: 'center',
+            justifyContent: 'flex-start',
             pointerEvents: 'none',
             userSelect: 'none',
           }}


### PR DESCRIPTION
## Summary
- Tick labels move from right-aligned inside the 58px label zone to left-aligned at `LABEL_WIDTH + 6` (just past the separator, into the bar zone)
- Reticle badge changes from `justifyContent: 'center'` to `flex-start` with `left: LABEL_WIDTH - 4`, so the HH:MM digits share a common left edge with tick labels
- Adds TODO comment in source noting the alignment invariant (no frontend test harness)
- Updates zone header comment to reflect new tick label position

## Test plan
- [ ] Verify tick labels render just right of the separator line at all zoom levels
- [ ] Verify reticle badge HH:MM left edge visually aligns with tick label left edges
- [ ] Verify event icons (at `LABEL_WIDTH - 18`) do not collide with tick labels (icons are in label zone, labels are now in bar zone — they should be spatially separated)
- [ ] Verify subpixel tick positioning unchanged (no snapping regression)
- [ ] Verify reticle badge remains `pointer-events: none`

🤖 Generated with [Claude Code](https://claude.com/claude-code)