### PR TITLE
fix(frontend): wrap resize handle siblings in correct JSX structure

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1197,6 +1197,7 @@ export default function App() {
             </div>
           </div>
         </div>
+      ) : null}
 
       <AdminPanel open={opsOpen} onClose={() => setOpsOpen(false)} />
     </div>


### PR DESCRIPTION
## Summary
- The ternary `!multiMode ? (` opened at line 1097 was never closed — the singleLayout `</div>` was correct, but the `) : null}` terminating the ternary was missing
- This caused esbuild to fail with `Expected ")" but found "open"` at the adjacent `<AdminPanel>` element
- Fix adds `) : null}` on its own line after the singleLayout closing div

## Test plan
- [x] `npm run build` exits 0 with no errors
- No logic, props, or behavior changed — structural JSX fix only

🤖 Generated with [Claude Code](https://claude.com/claude-code)