### PR TITLE
fix(frontend): zoom-aware scroll sensitivity and damping for precision at tight zoom

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -805,7 +805,15 @@ export default function VerticalTimeline({
     // 0.002: tight deadzone so very slow glides run to completion.
     const DEADZONE = secondsPerPixel * 0.002;
 
-    scrollVelocityRef.current *= DAMPING;
+    // zoomFactor: 0.0 at tightest zoom (5m), 1.0 at 1h and above.
+    // Provides zoom-aware sensitivity and damping without affecting
+    // the flywheel feel at wider zoom levels.
+    // At tight zoom decay faster for precision. At wide zoom use full
+    // DAMPING for the long flywheel glide.
+    const rangeSec = endTs - startTs;
+    const zoomFactor = Math.min(1.0, rangeSec / 3600);
+    const effectiveDamping = 0.88 + (DAMPING - 0.88) * zoomFactor;
+    scrollVelocityRef.current *= effectiveDamping;
 
     if (Math.abs(scrollVelocityRef.current) < DEADZONE) {
       scrollVelocityRef.current = 0;
@@ -815,7 +823,7 @@ export default function VerticalTimeline({
 
     onPan(scrollVelocityRef.current);
     scrollRafRef.current = requestAnimationFrame(decayScroll);
-  }, [onPan, secondsPerPixel]);
+  }, [onPan, secondsPerPixel, endTs, startTs]);
 
   const handleWheel = useCallback(
     (e) => {
@@ -838,7 +846,15 @@ export default function VerticalTimeline({
         * (normalizedDelta / 15) ** 2
         * 15;
 
-      const sensitivity = secondsPerPixel * K;
+      // zoomFactor: 0.0 at tightest zoom (5m), 1.0 at 1h and above.
+      // Provides zoom-aware sensitivity and damping without affecting
+      // the flywheel feel at wider zoom levels.
+      // Scale sensitivity down at tight zoom — more mass at small ranges.
+      // At 10m (600s range) this gives ~0.4x the normal sensitivity.
+      // At 1h+ it approaches 1.0x and the full flywheel feel is preserved.
+      const rangeSec = endTs - startTs;
+      const zoomFactor = Math.min(1.0, rangeSec / 3600);
+      const sensitivity = secondsPerPixel * K * (0.3 + 0.7 * zoomFactor);
       scrollVelocityRef.current += curved * sensitivity;
 
       // Impulse BEFORE clamp: first frame reflects raw intent.
@@ -1053,7 +1069,13 @@ export default function VerticalTimeline({
             const curvedDy = Math.sign(normalizedDy)
               * (normalizedDy / 60) ** 2
               * 60;
-            const deltaSec = curvedDy * secondsPerPixel * K_TOUCH;
+            // zoomFactor: 0.0 at tightest zoom (5m), 1.0 at 1h and above.
+            // Provides zoom-aware sensitivity and damping without affecting
+            // the flywheel feel at wider zoom levels.
+            const rangeSec = endTs - startTs;
+            const zoomFactor = Math.min(1.0, rangeSec / 3600);
+            const deltaSec = curvedDy * secondsPerPixel * K_TOUCH
+                             * (0.3 + 0.7 * zoomFactor);
             scrollVelocityRef.current = deltaSec;
             onPan(deltaSec);
             // Continuous tracking: update origin so each move delta is relative


### PR DESCRIPTION
## Summary

- Introduce `zoomFactor = min(1.0, rangeSec / 3600)` — 0.0 at 5m zoom, 1.0 at 1h and above
- Apply to wheel sensitivity: `K * (0.3 + 0.7 * zoomFactor)` — at 10m zoom gives ~0.4× normal sensitivity, at 1h+ unchanged
- Apply to touch sensitivity: same factor on `deltaSec` in `onTouchMove`
- Apply to decay: `effectiveDamping = 0.88 + (0.97 − 0.88) * zoomFactor` — tight zoom decays faster for precision; wide zoom keeps full flywheel glide
- Add `endTs`/`startTs` to `decayScroll` dependency array (required for zoom-aware damping to read current range)

DAMPING, K, K_TOUCH, maxV, DEADZONE, and the squared velocity curve are unchanged.

## Test plan

- [ ] At 10m zoom, a very slow swipe moves only 1–3 seconds
- [ ] At 1h zoom, flywheel feel is unchanged from before this commit
- [ ] At 1d zoom, a fast flick still carries several hours of glide
- [ ] Tap-to-recenter, zoom slider, and Prev/Next navigation unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)