### PR TITLE
fix(frontend): clamp cursor to camera latest_ts not wall-clock nowTs

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -220,7 +220,9 @@ export default function App() {
 
       lastInteractionRef.current = Date.now();
       autoplayActiveRef.current = false;
-      setCursorTs(prev => Math.min(prev + delta, nowTs()));
+      // TODO: test cursor ceiling — cursorTs must never exceed latest_ts for the
+      // selected camera; autoplay stops advancing when latest_ts is reached.
+      setCursorTs(prev => Math.min(prev + delta, latestCameraTsRef.current ?? nowTs()));
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
@@ -290,6 +292,18 @@ export default function App() {
   // selectedCameraRef: read by the stable RAF tick without stale closure.
   const selectedCameraRef = useRef(null);
   useEffect(() => { selectedCameraRef.current = selectedCamera; }, [selectedCamera]);
+
+  // latestCameraTs: the most recent segment end for the selected camera.
+  // Derived from /api/cameras response (cam.latest_ts). Clamping cursorTs
+  // to this value prevents autoplay and pan from advancing into the future
+  // beyond actual recordings.
+  const latestCameraTs = useMemo(() => {
+    const cam = cameras.find(c => c.name === selectedCamera);
+    return cam?.latest_ts ?? null;
+  }, [cameras, selectedCamera]);
+  // Ref mirror so the RAF tick can read the current ceiling without stale closure.
+  const latestCameraTsRef = useRef(null);
+  useEffect(() => { latestCameraTsRef.current = latestCameraTs; }, [latestCameraTs]);
   // preloadRequestRef: incremented on interaction to cancel in-flight preload fetches.
   // idlePreloadStartedRef: prevents re-firing preload within the same idle window.
   // TODO: test preload cancel — preloadRequestRef increment on interaction discards
@@ -380,7 +394,10 @@ export default function App() {
             }
           }
 
-          return Math.min(prev + advanceSec, nowTs());
+          // TODO: test cursor ceiling — cursorTs must never exceed latest_ts for the
+          // selected camera; autoplay stops advancing when latest_ts is reached.
+          const ceiling = latestCameraTsRef.current ?? nowTs();
+          return Math.min(prev + advanceSec, ceiling);
         });
       } else {
         if (autoplayActiveRef.current) {
@@ -582,14 +599,17 @@ export default function App() {
     nearEventCacheRef.current = { sorted, event: next };
   }, [filteredEvents]);
 
-  // ─── Pan: shift cursorTs by deltaSec, clamping at nowTs() ───
+  // ─── Pan: shift cursorTs by deltaSec, clamping at camera latest_ts ───
   const handlePan = useCallback((deltaSec) => {
     lastInteractionRef.current = Date.now();
     autoplayActiveRef.current = false;
     preloadRequestRef.current++; // cancel in-flight idle preload
     idlePreloadStartedRef.current = false; // allow fresh preload on next idle window
     setPreloadTarget(null);
-    setCursorTs(prev => Math.min(prev + deltaSec, nowTs()));
+    // TODO: test cursor ceiling — cursorTs must never exceed latest_ts for the
+    // selected camera; autoplay stops advancing when latest_ts is reached.
+    const ceiling = latestCameraTsRef.current ?? nowTs();
+    setCursorTs(prev => Math.min(prev + deltaSec, ceiling));
   }, []);
 
   // ─── Zoom: change visible window width, keeping cursorTs fixed ───


### PR DESCRIPTION
## Summary

- Add `latestCameraTs = useMemo(() => cameras.find(c => c.name === selectedCamera)?.latest_ts ?? null, [cameras, selectedCamera])`
- Mirror into `latestCameraTsRef` so the RAF tick reads the current ceiling without stale closure
- Thread `latestCameraTsRef.current ?? nowTs()` as the ceiling into three clamp sites: autoplay RAF tick, `handlePan`, ArrowRight keyboard handler

## Root cause

The autoplay RAF loop and pan handler both clamped `cursorTs` to `nowTs()` (wall-clock). When autoplay ran or the user scrolled forward near live time, the cursor advanced hours past the last actual recording. This caused:
1. `[VerticalTimeline]` "Events present but not visible" sentinel fired every render (visible window was ahead of all events)
2. `fetchPlaybackTarget` found no segment → video never loaded
3. Preview images didn't exist for future timestamps

## What was not changed

- `rangeEnd` ceiling (`nowTs() + 60`) — correct, keeps the range window anchored to wall clock
- Initial `cursorTs` (`nowTs()`) — correct, starts at live position
- Camera-switch `setCursorTs(cam?.latest_ts ?? nowTs())` — unchanged, already used `latest_ts`

## Test plan

- [ ] Autoplay stops advancing when `cursorTs` reaches `latest_ts` for the selected camera
- [ ] Pan forward past `latest_ts` is clamped — cursor does not overshoot into the future
- [ ] ArrowRight key held down stops at `latest_ts`
- [ ] Camera switch still lands at `latest_ts` for the new camera (unchanged behavior)
- [ ] `nowTs()` fallback fires correctly when `latest_ts` is null (no cameras loaded yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)