### PR TITLE
fix(preview): store actual output dimensions instead of assuming 16:9

### DIFF
--- a/backend/app/services/preview_generator.py
+++ b/backend/app/services/preview_generator.py
@@ -25,6 +25,8 @@ import threading
 from datetime import datetime, timezone
 from pathlib import Path
 
+from PIL import Image
+
 from app.config import settings
 
 log = logging.getLogger(__name__)
@@ -116,13 +118,24 @@ def extract_preview_frame(
     output_path = day_dir / filename
 
     if output_path.exists():
+        # Read actual output dimensions — do not assume 16:9.
+        # ffmpeg scale={width}:-1 preserves source aspect ratio, so cameras
+        # that are not 16:9 (e.g. Ubiquiti 4:3) will produce a different height.
+        # PIL header-only open is O(1) — it reads only the JPEG SOF marker.
+        actual_width = width
+        actual_height = int(width * 9 / 16)  # safe fallback if PIL read fails
+        try:
+            with Image.open(output_path) as _img:
+                actual_width, actual_height = _img.size
+        except Exception:
+            pass  # fallback to 16:9 estimate — non-fatal
         return {
             "ts": ts,
             "camera": camera,
             "segment_id": segment["id"],
             "image_path": str(output_path.relative_to(settings.preview_output_path)),
-            "width": width,
-            "height": int(width * 9 / 16),
+            "width": actual_width,
+            "height": actual_height,
         }
 
     # Step 3 — Run exactly ONE ffmpeg subprocess
@@ -169,13 +182,24 @@ def extract_preview_frame(
 
     # Step 4 — Return result or None
     if result.returncode == 0 and output_path.exists():
+        # Read actual output dimensions — do not assume 16:9.
+        # ffmpeg scale={width}:-1 preserves source aspect ratio, so cameras
+        # that are not 16:9 (e.g. Ubiquiti 4:3) will produce a different height.
+        # PIL header-only open is O(1) — it reads only the JPEG SOF marker.
+        actual_width = width
+        actual_height = int(width * 9 / 16)  # safe fallback if PIL read fails
+        try:
+            with Image.open(output_path) as _img:
+                actual_width, actual_height = _img.size
+        except Exception:
+            pass  # fallback to 16:9 estimate — non-fatal
         return {
             "ts": ts,
             "camera": camera,
             "segment_id": segment["id"],
             "image_path": str(output_path.relative_to(settings.preview_output_path)),
-            "width": width,
-            "height": int(width * 9 / 16),
+            "width": actual_width,
+            "height": actual_height,
         }
 
     log.debug("Preview extraction failed for %s ts=%.2f", camera, ts)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,6 +5,7 @@ httpx==0.28.1
 python-dotenv==1.0.1
 pydantic==2.10.4
 pydantic-settings==2.7.1
+Pillow>=10.0.0
 
 # Testing
 pytest==8.3.4

--- a/backend/tests/unit/test_preview_generator_v2.py
+++ b/backend/tests/unit/test_preview_generator_v2.py
@@ -192,6 +192,82 @@ class TestExtractPreviewFrame:
 
         mock_connect.assert_not_called()
 
+    def test_stores_actual_dimensions_not_assumed_16x9(self, tmp_path, monkeypatch):
+        """Actual file dimensions are used, not hardcoded 16:9."""
+        from PIL import Image as PILImage
+
+        recordings = tmp_path / "recordings"
+        previews = tmp_path / "previews"
+        recordings.mkdir()
+        previews.mkdir()
+
+        import app.services.preview_generator as pg
+        _patch_settings(monkeypatch, recordings, previews, tmp_path / "db.sqlite3")
+        monkeypatch.setattr(pg, "_VAAPI_DEVICE", None)
+
+        segment = _make_segment(recordings, camera="cam")
+        ts = 1700000004.0
+
+        def fake_run(cmd, **kwargs):
+            out_path = Path(cmd[-1])
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            img = PILImage.new("RGB", (320, 240), color=(128, 128, 128))
+            img.save(out_path, "JPEG")
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        with patch("app.services.preview_generator.subprocess.run",
+                   side_effect=fake_run):
+            frame = pg.extract_preview_frame(
+                camera="cam", ts=ts, width=320, quality=5, segment=segment,
+            )
+
+        assert frame is not None
+        assert frame["width"] == 320
+        assert frame["height"] == 240, (
+            f"Expected height=240 (actual 4:3 output), got {frame['height']}. "
+            "Do not assume 16:9 — read dimensions from the output file."
+        )
+
+    def test_falls_back_to_16x9_estimate_if_pil_fails(self, tmp_path, monkeypatch):
+        """Returns a valid frame dict with the fallback height when PIL.Image.open raises."""
+        recordings = tmp_path / "recordings"
+        previews = tmp_path / "previews"
+        recordings.mkdir()
+        previews.mkdir()
+
+        import app.services.preview_generator as pg
+        _patch_settings(monkeypatch, recordings, previews, tmp_path / "db.sqlite3")
+        monkeypatch.setattr(pg, "_VAAPI_DEVICE", None)
+
+        segment = _make_segment(recordings, camera="cam")
+        ts = 1700000004.0
+
+        def fake_run(cmd, **kwargs):
+            out_path = Path(cmd[-1])
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            out_path.write_bytes(b"fake jpeg")
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        with patch("app.services.preview_generator.subprocess.run",
+                   side_effect=fake_run):
+            with patch("app.services.preview_generator.Image.open",
+                       side_effect=OSError("corrupt header")):
+                frame = pg.extract_preview_frame(
+                    camera="cam", ts=ts, width=320, quality=5, segment=segment,
+                )
+
+        assert frame is not None, "Must return a valid frame dict even when PIL fails"
+        assert frame["width"] == 320
+        assert frame["height"] == int(320 * 9 / 16), (
+            "Fallback height should be the 16:9 estimate when PIL.Image.open raises"
+        )
+
     def test_returns_none_if_segment_not_found(self, tmp_path, monkeypatch):
         """Returns None without calling subprocess.run if DB has no matching segment."""
         recordings = tmp_path / "recordings"


### PR DESCRIPTION
## Summary

- `extract_preview_frame` was storing `int(width * 9 / 16)` as the preview height, but ffmpeg uses `scale={width}:-1` which preserves the source aspect ratio. Non-16:9 cameras (Ubiquiti 4:3) produce a different output height, making the stored value wrong.
- Fix: read actual dimensions from the generated JPEG via `PIL.Image.open()` immediately after ffmpeg writes the file. PIL opens in header-only mode (reads the JPEG SOF marker only), so this is O(1) and adds negligible latency.
- Falls back silently to `int(width * 9 / 16)` if PIL raises for any reason — preview generation degrades gracefully per CLAUDE.md invariants.
- Both return sites patched: the early-return (file already existed) branch and the post-ffmpeg success branch.
- Added `Pillow>=10.0.0` to `requirements.txt` (was a transitive dep only).

## Tests

Two new tests in `test_preview_generator_v2.py`:
- `test_stores_actual_dimensions_not_assumed_16x9`: creates a real 320×240 JPEG via Pillow in `fake_run`, asserts `height=240` not `180`.
- `test_falls_back_to_16x9_estimate_if_pil_fails`: patches `Image.open` to raise, asserts function still returns a valid dict with the 16:9 fallback height.

All 149 backend tests pass.

## Invariants preserved

- `extract_preview_frame` returns `None` on ffmpeg failure — PIL read only runs inside the `returncode == 0 and output_path.exists()` success branch.
- No DB call, ffprobe call, or filesystem scan added to any read path.
- No schema migration needed — `previews` table already has separate `width` and `height` columns.