### PR TITLE
fix(preview): gate Frigate snapshot fallback on segment absence

### DIFF
--- a/backend/app/routers/preview.py
+++ b/backend/app/routers/preview.py
@@ -164,7 +164,19 @@ async def get_preview_frame(camera: str, timestamp: float):
                 bucket_ts = alt_ts
                 break
         else:
-            # No adjacent bucket found — Phase 7: try Frigate event snapshot
+            # No adjacent bucket found.
+            # Only fall back to Frigate snapshot when no local segment covers
+            # this ts. If a segment exists, generation is possible — enqueue
+            # and return 404 rather than serving a potentially stale or
+            # off-timestamp Frigate event thumbnail.
+            if await _segment_exists_for_ts(camera, bucket_ts):
+                enqueue_preview_request(camera, bucket_ts, bucket_ts + interval)
+                raise HTTPException(
+                    status_code=404,
+                    detail="Preview not yet generated — enqueued",
+                )
+
+            # Phase 7: no local segment — try Frigate event snapshot as last resort
             snapshot_data = await _try_frigate_event_snapshot(camera, timestamp)
             if snapshot_data:
                 _cache.put(camera, bucket_ts, snapshot_data)
@@ -204,12 +216,27 @@ async def get_preview_frame(camera: str, timestamp: float):
     )
 
 
+async def _segment_exists_for_ts(camera: str, ts: float) -> bool:
+    """Return True if any segment covers this timestamp (generation is possible)."""
+    async with get_db() as db:
+        rows = await db.execute_fetchall(
+            """SELECT 1 FROM segments
+               WHERE camera = ? AND start_ts <= ? AND end_ts >= ?
+               LIMIT 1""",
+            (camera, ts, ts),
+        )
+    return len(rows) > 0
+
+
 async def _try_frigate_event_snapshot(camera: str, timestamp: float) -> bytes | None:
     """Serve the best Frigate event snapshot overlapping this timestamp.
 
     Selection: highest confidence score; ties broken by temporal proximity.
     If a snapshot is returned, the caller MUST NOT enqueue a generation job —
     Frigate already has the best available frame.
+
+    Only called when no local segment covers the requested timestamp — i.e.
+    local generation is not possible. Do not invoke on routine cache misses.
     """
     try:
         async with get_db() as db:
@@ -222,7 +249,7 @@ async def _try_frigate_event_snapshot(camera: str, timestamp: float) -> bytes | 
                      AND has_snapshot = 1
                    ORDER BY score DESC, ABS(start_ts - ?) ASC
                    LIMIT 1""",
-                (camera, timestamp + 5.0, timestamp - 5.0, timestamp),
+                (camera, timestamp + 2.0, timestamp - 2.0, timestamp),
             )
         if not rows:
             return None

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -83,6 +83,63 @@ async def test_preview_progress_empty(client):
     assert isinstance(resp.json(), list)
 
 
+async def test_preview_returns_404_not_snapshot_when_segment_exists(
+    client, monkeypatch
+):
+    """Frigate snapshot fallback must NOT fire when a local segment covers the ts.
+
+    Contract: segment present → enqueue + 404. _try_frigate_event_snapshot
+    must never be called so we don't serve stale or off-timestamp thumbnails
+    while local generation is pending.
+    """
+    from unittest.mock import AsyncMock
+    from app import config
+
+    db_path = config.settings.database_path
+    ts = 1700100000.0
+    # Insert a segment that covers `ts` — no preview file on disk
+    _insert_segment(db_path, "seg-gate-cam", ts - 5.0, ts + 5.0, previews_generated=0)
+
+    called = []
+
+    async def fake_snapshot(camera, timestamp):
+        called.append((camera, timestamp))
+        return b"fake-snapshot-bytes"
+
+    monkeypatch.setattr("app.routers.preview._try_frigate_event_snapshot", fake_snapshot)
+
+    resp = await client.get(f"/api/preview/seg-gate-cam/{ts}")
+    assert resp.status_code == 404, (
+        "Expected 404 when segment exists but preview not yet generated"
+    )
+    assert called == [], (
+        "_try_frigate_event_snapshot must NOT be called when a segment covers the ts"
+    )
+
+
+async def test_preview_calls_frigate_fallback_when_no_segment(client, monkeypatch):
+    """Frigate snapshot fallback fires when no local segment covers the ts.
+
+    Contract: no segment → try Frigate snapshot → 200 FRIGATE-SNAPSHOT.
+    """
+    from app import config
+
+    # Intentionally do NOT insert a segment for this camera/ts
+    ts = 1700200000.0
+
+    async def fake_snapshot(camera, timestamp):
+        return b"\xff\xd8\xff\xe0fake-jpeg"  # minimal fake JPEG bytes
+
+    monkeypatch.setattr("app.routers.preview._try_frigate_event_snapshot", fake_snapshot)
+
+    resp = await client.get(f"/api/preview/no-seg-cam/{ts}")
+    assert resp.status_code == 200, (
+        "Expected 200 when no segment exists and Frigate snapshot is available"
+    )
+    assert resp.headers.get("x-cache") == "FRIGATE-SNAPSHOT"
+    assert resp.content == b"\xff\xd8\xff\xe0fake-jpeg"
+
+
 # ---------------------------------------------------------------------------
 # Timeline
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The Frigate event snapshot fallback was firing on every filesystem miss — which is the normal state for any timestamp whose preview hasn't been generated yet. This caused the frontend to display low-quality Frigate event thumbnails instead of timestamp-accurate local previews, even when local footage existed and generation was pending.

- **New `_segment_exists_for_ts` helper:** single `LIMIT 1` DB query that returns True when any segment covers the requested timestamp. Only executes after cache miss + filesystem miss + adjacent bucket miss — not on the hot path.
- **Gate in `get_preview_frame`:** if a segment exists, enqueue generation and return 404 immediately. Frigate fallback only runs when no local segment covers the timestamp.
- **Tightened match window in `_try_frigate_event_snapshot`:** ±5s → ±2s to reduce false positives where loosely related event snapshots were returned.

## New contract

| Condition | Behavior |
|-----------|----------|
| Segment exists, preview not yet generated | Enqueue + 404 |
| No segment covers the timestamp | Try Frigate snapshot |
| No segment, Frigate snapshot available | 200 FRIGATE-SNAPSHOT |
| No segment, no Frigate snapshot | Enqueue + 404 |

## Tests

Two new integration tests in `test_api.py`:
- `test_preview_returns_404_not_snapshot_when_segment_exists` — segment in DB, no preview file, asserts 404 and that `_try_frigate_event_snapshot` is never called.
- `test_preview_calls_frigate_fallback_when_no_segment` — no segment in DB, mock snapshot returns bytes, asserts 200 with `X-Cache: FRIGATE-SNAPSHOT`.

All 151 backend tests pass.

## Invariants preserved

- Preview endpoint remains O(1) on cache hit — `_segment_exists_for_ts` is not on the hot path.
- No synchronous generation added to the preview lookup path.
- `enqueue_preview_request` still called in both branches.