### PR TITLE
fix(frontend): pad timeline fetch window to prevent autoplay event drift

### DIFF
--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -248,6 +248,55 @@ async def test_timeline_events_within_requested_range(client):
         )
 
 
+async def test_timeline_returns_events_outside_tight_range_when_padded(client):
+    """Backend correctly returns events that fall within a padded fetch window.
+
+    Documents the App.jsx padded-fetch pattern: when the frontend fetches
+    [rangeStart - rangeSec, rangeEnd + rangeSec] instead of the tight visible
+    window, events up to rangeSec before the visible bottom are returned and
+    available for navigation / rendering as the cursor advances.
+    """
+    from app import config
+    db_path = config.settings.database_path
+
+    tight_start = 1700070000.0
+    tight_end   = 1700080000.0   # 10 000-second tight window
+    range_sec   = tight_end - tight_start
+
+    # Event inside the tight visible window
+    _insert_event(db_path, "padded-cam", tight_start + 500, tight_start + 600)
+    # Event just outside the bottom of the tight window (30 min before tight_start)
+    _insert_event(db_path, "padded-cam", tight_start - 1800, tight_start - 1700)
+
+    # Fetch with tight window — event outside should NOT appear
+    resp_tight = await client.get(
+        "/api/timeline",
+        params={"camera": "padded-cam", "start": tight_start, "end": tight_end},
+    )
+    assert resp_tight.status_code == 200
+    tight_ts = {e["start_ts"] for e in resp_tight.json()["events"]}
+    assert tight_start + 500 in tight_ts, "In-window event must appear in tight fetch"
+    assert tight_start - 1800 not in tight_ts, (
+        "Out-of-window event must not appear in tight fetch"
+    )
+
+    # Fetch with padded window — event outside tight window SHOULD appear
+    padded_start = tight_start - range_sec
+    padded_end   = tight_end + range_sec
+    resp_padded = await client.get(
+        "/api/timeline",
+        params={"camera": "padded-cam", "start": padded_start, "end": padded_end},
+    )
+    assert resp_padded.status_code == 200
+    padded_ts = {e["start_ts"] for e in resp_padded.json()["events"]}
+    assert tight_start + 500 in padded_ts, "In-window event must appear in padded fetch"
+    assert tight_start - 1800 in padded_ts, (
+        "Event just below tight window must appear in padded fetch"
+    )
+
+
+
+
 # ---------------------------------------------------------------------------
 # Playback / gap snapping
 # ---------------------------------------------------------------------------

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -485,8 +485,17 @@ export default function App() {
     const timer = setTimeout(async () => {
       try {
         const opts = { signal: controller.signal };
+        // Pad the timeline fetch window by 1x rangeSec on each side so that
+        // events fetched during autoplay remain valid for ~rangeSec worth of
+        // cursor advance before drifting below startTs. This prevents the
+        // "[Events present but not visible]" warning that fires when the 300ms
+        // debounce causes filteredEvents to lag behind the advancing visible window.
+        // fetchPreviewStrip uses the tight window — pixel-dense strips don't
+        // need the padding and fetching 3x would over-fetch frame URLs.
+        const fetchStart = rangeStart - rangeSec;
+        const fetchEnd = rangeEnd + rangeSec;
         const [tl, strip] = await Promise.all([
-          fetchTimeline(selectedCamera, rangeStart, rangeEnd, opts),
+          fetchTimeline(selectedCamera, fetchStart, fetchEnd, opts),
           fetchPreviewStrip(selectedCamera, rangeStart, rangeEnd, 300, opts),
         ]);
 

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -534,13 +534,24 @@ export default function VerticalTimeline({
     }
 
     if (events.length > 0 && renderedEventCount === 0) {
-      console.warn('[VerticalTimeline] Events present but not visible', {
-        eventCount: events.length,
-        startTs,
-        endTs,
-        minEventTs: Math.min(...events.map(e => e.start_ts ?? e.start_time ?? 0)),
-        maxEventTs: Math.max(...events.map(e => e.start_ts ?? e.start_time ?? 0)),
+      // Only warn when events that fall within the visible range didn't render.
+      // Events outside [startTs, endTs] are expected when the fetch window is
+      // wider than the visible range (padded fetch in App.jsx) — those events
+      // are off-canvas by design, not a rendering failure.
+      const anyInRange = events.some(e => {
+        const ts = e.start_ts ?? e.start_time ?? e.timestamp;
+        return ts != null && ts >= startTs && ts <= endTs;
       });
+      if (anyInRange) {
+        console.warn('[VerticalTimeline] Events present but not visible', {
+          eventCount: events.length,
+          startTs,
+          endTs,
+          minEventTs: Math.min(...events.map(e => e.start_ts ?? e.start_time ?? 0)),
+          maxEventTs: Math.max(...events.map(e => e.start_ts ?? e.start_time ?? 0)),
+        });
+      }
+      // events outside visible range: expected with padded fetch window — no warn
     }
 
     // Sort by proximity to reticle so icon collision keeps closest events.


### PR DESCRIPTION
## Root cause

During autoplay, `cursorTs` advances at ~60fps via the RAF loop. The timeline fetch is debounced 300ms, so `timelineData` — and therefore `filteredEvents` — lags behind. As `cursorTs` advances, `rangeStart` walks forward. Events near the bottom of the *previous* fetch window fall below the new `startTs` and the canvas warn guard fires hundreds of times:

```
[VerticalTimeline] Events present but not visible
  startTs:    1774212279   (visible window bottom)
  maxEventTs: 1774210886   (~23 minutes below startTs)
```

The events are real and correctly fetched — the visible window simply advanced past them between fetch cycles.

## Changes

### `frontend/src/App.jsx` — padded fetch window (primary fix)

Timeline fetch now requests `[rangeStart - rangeSec, rangeEnd + rangeSec]` instead of the tight visible window. Events fetched during one debounce cycle remain valid for up to `rangeSec` of cursor advance before drifting off the bottom edge.

`fetchPreviewStrip` keeps the tight `[rangeStart, rangeEnd]` window — pixel-dense frame strips don't need the padding and fetching 3× the range would over-fetch URLs.

### `frontend/src/components/VerticalTimeline.jsx` — tighten warn guard

The warn guard now only fires when events with `start_ts` *within* `[startTs, endTs]` failed to render. Events outside the visible range are expected with the padded fetch and silently skipped — they're off-canvas by design, not a rendering failure.

### `backend/tests/integration/test_api.py` — new test

`test_timeline_returns_events_outside_tight_range_when_padded` verifies:
- Tight fetch: only in-window event returned ✓
- Padded fetch: both in-window and just-outside-window events returned ✓

## Invariants preserved

- `cursorTs` is never implicitly changed
- No per-frame network requests; 300ms debounce unchanged
- `fetchPreviewStrip` uses the tight window
- `filteredEvents` post-filter already accepted padded events (`rangeStart - rangeSec` lower bound) — no change needed

## Test plan

- [x] `pytest tests/` — 153 passed, 1 warning
- [ ] Manual: enable autoplay, confirm "[Events present but not visible]" warnings no longer appear
- [ ] Manual: events near the bottom of the visible range render correctly and prev/next navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)