### PR TITLE
feat(frontend): debug tab event log with relative timestamps

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -39,6 +39,12 @@ import {
 import { nowTs, formatDateTime, formatTime, formatTimeShort, formatDayDate, bucketSizeForRange } from './utils/time.js';
 import { RETICLE_FRACTION } from './utils/constants.js';
 
+// Record page-load time for debug event log relative timestamps.
+// Runs once at module scope — all log entries are relative to this moment.
+if (import.meta.env.DEV) {
+  window.__debugAppStart = Date.now();
+}
+
 // Autoplay: idle threshold before timeline starts advancing.
 const AUTOPLAY_DELAY_MS = 1500;
 // Preload: start background HLS fetch this many ms after last interaction.
@@ -227,6 +233,7 @@ export default function App() {
 
       lastInteractionRef.current = Date.now();
       autoplayActiveRef.current = false;
+      if (import.meta.env.DEV) debugEventRef.current?.('interaction', 'keyboard');
       // TODO: test cursor ceiling — cursorTs must never exceed latest_ts for the
       // selected camera; autoplay stops advancing when latest_ts is reached.
       // TODO: test ceiling slack — cursor may reach latest_ts + 30 but no further.
@@ -282,6 +289,14 @@ export default function App() {
   const [debugScrubPreviewStatus, setDebugScrubPreviewStatus] = useState(null);
   const [debugIsPlaying, setDebugIsPlaying] = useState(false);
   const [debugDisplayedUrl, setDebugDisplayedUrl] = useState(null);
+
+  // Stable ref to DebugTab's addEntry function, registered by DebugTab on mount.
+  // App.jsx and VideoPlayer.jsx fire-and-forget into this ref — no re-render cost.
+  const debugEventRef = useRef(null);
+  // Stable callback wrapper — safe to pass as prop without causing VideoPlayer re-renders.
+  const onDebugEventStable = useCallback((l, d) => {
+    if (import.meta.env.DEV) debugEventRef.current?.(l, d);
+  }, []); // stable — ref reads are always current
 
   // Idle preload: PlaybackTarget fetched during idle window, promoted to
   // playbackTarget when AUTOPLAY_DELAY_MS fires.
@@ -369,7 +384,10 @@ export default function App() {
           fetchPlaybackTarget(cam, ts)
             .then(target => {
               if (myId !== preloadRequestRef.current) return; // cancelled by interaction
-              if (target) setPreloadTarget(target);
+              if (target) {
+                setPreloadTarget(target);
+                if (import.meta.env.DEV) debugEventRef.current?.('preloadTarget set', `ts=${target.requested_ts}, hls=${target.hls_url ? 'ready' : 'none'}`);
+              }
             })
             .catch((e) => { console.warn('[RAF] idle preload fetch failed:', e.message); });
         }
@@ -381,6 +399,7 @@ export default function App() {
           autoplayActiveRef.current = true;
           autoplayStartRef.current = now;
           console.log('[RAF] autoplay threshold reached — setAutoplayRunning(true)', { idleMs, preloadReady: !!preloadTargetRef.current, cam: selectedCameraRef.current, ts: cursorTsRef.current });
+          if (import.meta.env.DEV) debugEventRef.current?.('autoplay fired', `preloadTarget=${preloadTargetRef.current ? 'ready' : 'none'} at this moment`);
           setAutoplayRunning(true); // triggers preload→playback promotion in useEffect
         }
 
@@ -458,6 +477,7 @@ export default function App() {
 
         setCameras(cams);
         setHealth(hp);
+        if (import.meta.env.DEV) debugEventRef.current?.('app init', `cursorTs=${Math.round(cursorTsRef.current ?? 0)}, camera=${cams[0]?.name ?? 'none'}`);
         // TODO: when a frontend test harness is introduced, add a test that
         // verifies the 30s health poll does NOT reset selectedCamera when one
         // is already active. See CLAUDE.md "Example prompt" for context.
@@ -650,6 +670,10 @@ export default function App() {
     autoplayActiveRef.current = false;
     preloadRequestRef.current++; // cancel in-flight idle preload
     idlePreloadStartedRef.current = false; // allow fresh preload on next idle window
+    if (import.meta.env.DEV) {
+      debugEventRef.current?.('interaction', 'pan');
+      debugEventRef.current?.('preloadTarget cleared', 'reason=interaction');
+    }
     setPreloadTarget(null);
     // TODO: test cursor ceiling — cursorTs must never exceed latest_ts for the
     // selected camera; autoplay stops advancing when latest_ts is reached.
@@ -666,6 +690,10 @@ export default function App() {
     autoplayActiveRef.current = false;
     preloadRequestRef.current++; // cancel in-flight idle preload
     idlePreloadStartedRef.current = false; // allow fresh preload on next idle window
+    if (import.meta.env.DEV) {
+      debugEventRef.current?.('interaction', 'zoom');
+      debugEventRef.current?.('preloadTarget cleared', 'reason=interaction');
+    }
     setPreloadTarget(null);
     if (newRangeSec < MIN_RANGE_SEC || newRangeSec > MAX_RANGE_SEC) return;
     setRangeSec(newRangeSec);
@@ -681,6 +709,10 @@ export default function App() {
     autoplayActiveRef.current = false;
     preloadRequestRef.current++; // cancel in-flight idle preload
     idlePreloadStartedRef.current = false; // allow fresh preload after 400ms
+    if (import.meta.env.DEV) {
+      debugEventRef.current?.('seek', `ts=${Math.round(ts)}`);
+      debugEventRef.current?.('preloadTarget cleared', 'reason=interaction');
+    }
     setPreloadTarget(null);
     setAutoplayRunning(false);
     setCursorTs(ts);
@@ -701,6 +733,7 @@ export default function App() {
         const myId = seekRequestIdRef.current;
         const target = await fetchPlaybackTarget(selectedCamera, info.start_ts + 0.1);
         if (myId !== seekRequestIdRef.current) return;
+        if (import.meta.env.DEV && target) debugEventRef.current?.('playbackTarget set', `ts=${target.requested_ts}, offset=${target.offset_sec}s`);
         console.log('[APP] setPlaybackTarget from auto-advance', target);
         setPlaybackTarget(target);
       } catch {
@@ -749,6 +782,7 @@ export default function App() {
   }, []);
 
   const handleDebugClearPlayback = useCallback(() => {
+    if (import.meta.env.DEV) debugEventRef.current?.('playbackTarget cleared', 'reason=debug');
     setPlaybackTarget(null);
   }, []);
 
@@ -773,6 +807,11 @@ export default function App() {
   useEffect(() => {
     if (!autoplayRunning) return;
     if (!preloadTarget) return; // wait for Effect B fallback
+    if (import.meta.env.DEV) {
+      debugEventRef.current?.('promote: preload→playback', `ts=${preloadTarget.requested_ts}`);
+      debugEventRef.current?.('preloadTarget cleared', 'reason=promoted');
+      debugEventRef.current?.('playbackTarget set', `ts=${preloadTarget.requested_ts}, offset=${preloadTarget.offset_sec}s`);
+    }
     console.log('[APP] autoplay: promoting preload target', preloadTarget);
     setPlaybackTarget(preloadTarget);
     setPreloadTarget(null);
@@ -792,12 +831,18 @@ export default function App() {
       const cam = selectedCameraRef.current;
       const ts = cursorTsRef.current;
       if (!cam || ts == null) return;
+      if (import.meta.env.DEV) debugEventRef.current?.('fallback fetch started', `cursorTs=${Math.round(ts)}`);
       fetchPlaybackTarget(cam, ts)
         .then(target => {
           if (autoplayActiveRef.current && target) {
+            if (import.meta.env.DEV) {
+              debugEventRef.current?.('fallback fetch done', `ts=${target.requested_ts}, status=ok`);
+              debugEventRef.current?.('playbackTarget set', `ts=${target.requested_ts}, offset=${target.offset_sec}s`);
+            }
             console.log('[APP] autoplay: fallback fetch', target);
             setPlaybackTarget(target);
           } else if (!target) {
+            if (import.meta.env.DEV) debugEventRef.current?.('fallback fetch done', `ts=${Math.round(ts)}, status=null`);
             console.warn('[APP] autoplay: fallback fetch returned null — no segment at ts', ts);
           }
         })
@@ -819,6 +864,11 @@ export default function App() {
   const handleCameraChange = useCallback((name) => {
     preloadRequestRef.current++; // cancel in-flight idle preload for old camera
     idlePreloadStartedRef.current = false;
+    if (import.meta.env.DEV) {
+      debugEventRef.current?.('camera switch', `→ ${name}`);
+      debugEventRef.current?.('preloadTarget cleared', 'reason=camera-switch');
+      debugEventRef.current?.('playbackTarget cleared', 'reason=camera-switch');
+    }
     setPreloadTarget(null);
     setAutoplayRunning(false);
     setSelectedCamera(name);
@@ -900,6 +950,7 @@ export default function App() {
       const myId = seekRequestIdRef.current;
       const playTarget = await fetchPlaybackTarget(selectedCamera, targetTs);
       if (myId !== seekRequestIdRef.current) return;
+      if (import.meta.env.DEV && playTarget) debugEventRef.current?.('playbackTarget set', `ts=${playTarget.requested_ts}, offset=${playTarget.offset_sec}s`);
       console.log('[APP] setPlaybackTarget from event navigation', playTarget);
       setPlaybackTarget(playTarget);
     } catch {}
@@ -1185,6 +1236,7 @@ export default function App() {
                 onScrubPreviewStatus={import.meta.env.DEV ? setDebugScrubPreviewStatus : null}
                 onDebugIsPlaying={import.meta.env.DEV ? setDebugIsPlaying : null}
                 onDebugDisplayedUrl={import.meta.env.DEV ? setDebugDisplayedUrl : null}
+                onDebugEvent={import.meta.env.DEV ? onDebugEventStable : null}
               />
             </div>
 
@@ -1284,6 +1336,7 @@ export default function App() {
           onDebugTriggerAutoplay: handleDebugTriggerAutoplay,
           onDebugPromotePreload: handleDebugPromotePreload,
           onDebugClearPlayback: handleDebugClearPlayback,
+          registerDebugLog: (fn) => { debugEventRef.current = fn; },
         } : {})}
       />
     </div>

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -423,6 +423,9 @@ function LogPane({ lines, isLive, filter, onFilterChange }) {
 // ── DebugTab (DEV only) ───────────────────────────────────────────────────────
 // TODO: test debug tab hidden in production (import.meta.env.DEV=false)
 // TODO: test forceShowScrubOverlay bypasses autoplayActive condition
+// TODO: test event log entries fire in correct order for:
+//   idle → preloadTarget set → autoplay → promote path
+//   idle → preload too slow → autoplay → fallback path
 function DebugTab({
   debugOverrides,
   setDebugOverrides,
@@ -430,9 +433,34 @@ function DebugTab({
   onDebugTriggerAutoplay,
   onDebugPromotePreload,
   onDebugClearPlayback,
+  registerDebugLog,
 }) {
   const [queueStats, setQueueStats] = useState(null);
   const [, setTick] = useState(0); // 500ms refresh for readouts
+
+  // Event log state
+  const [logEntries, setLogEntries] = useState([]);
+  const logRef = useRef(null);
+  const [userScrolled, setUserScrolled] = useState(false);
+
+  // Register addEntry with App.jsx so it can push events fire-and-forget.
+  // Effect runs once; registerDebugLog writes to a ref in App.jsx so [] is safe.
+  useEffect(() => {
+    if (!registerDebugLog) return;
+    registerDebugLog((label, detail) => {
+      setLogEntries(prev => {
+        const entry = { ms: Date.now() - (window.__debugAppStart ?? 0), label, detail: detail ?? '' };
+        return prev.length >= 200 ? [...prev.slice(1), entry] : [...prev, entry];
+      });
+    });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Auto-scroll to bottom unless the user has scrolled up.
+  useEffect(() => {
+    const el = logRef.current;
+    if (!el || userScrolled) return;
+    el.scrollTop = el.scrollHeight;
+  }, [logEntries, userScrolled]);
 
   // Track when autoplayActive first became true — used for the stalled-video warning.
   const autoplayActiveSinceRef = useRef(null);
@@ -586,6 +614,29 @@ function DebugTab({
     );
   }
 
+  // ── Event log helpers ───────────────────────────────────────────────────────
+
+  function labelColor(label) {
+    if (/^(seek|interaction|camera switch)$/.test(label)) return '#4ecdc4';
+    if (/^preloadTarget/.test(label)) return '#c77dff';
+    if (/^(autoplay fired|promote:|fallback fetch)/.test(label)) return '#ffd93d';
+    if (/^playbackTarget/.test(label)) return '#6bcb77';
+    if (/^video (play|pause|stalled|ended)$/.test(label)) return '#FF9800';
+    if (/^(HLS manifest|HLS error|preload swap)/.test(label)) return '#2196F3';
+    if (label === 'preview 200') return '#4CAF50';
+    if (label === 'preview 404') return '#ff6b6b';
+    if (label === 'preview displayed') return '#8BC34A';
+    if (label === 'app init') return '#888';
+    return '#aaa';
+  }
+
+  function copyLog() {
+    const text = logEntries.map(e =>
+      `+${String(e.ms).padStart(6)}ms  ${e.label}  ${e.detail}`
+    ).join('\n');
+    navigator.clipboard.writeText(text).catch(() => {});
+  }
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
@@ -730,6 +781,64 @@ function DebugTab({
             color="#ffd93d"
           />
         </ActionGroup>
+      </div>
+
+      {/* ── Section 4: Event Log ── */}
+      <div style={sd.section}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 8 }}>
+          <div style={sd.sectionTitle}>Event log</div>
+          <div style={{ display: 'flex', gap: 6 }}>
+            <button
+              onClick={() => { setLogEntries([]); setUserScrolled(false); }}
+              style={sd.logBtn}
+            >Clear</button>
+            <button onClick={copyLog} style={sd.logBtn}>Copy</button>
+          </div>
+        </div>
+        <div
+          ref={logRef}
+          onScroll={e => {
+            const el = e.currentTarget;
+            setUserScrolled(el.scrollTop + el.clientHeight < el.scrollHeight - 20);
+          }}
+          style={{
+            height: 280, overflowY: 'auto',
+            background: '#0a0c12', border: '1px solid #1e2130', borderRadius: 3,
+            fontFamily: 'monospace', fontSize: 11, lineHeight: 1.6,
+          }}
+        >
+          {logEntries.length === 0 && (
+            <div style={{ color: '#333', padding: '8px 10px' }}>
+              No events yet — interact with the timeline.
+            </div>
+          )}
+          {logEntries.map((e, i) => (
+            <div key={i} style={{ display: 'flex', padding: '0 6px', minHeight: '1.6em' }}>
+              <span style={{
+                width: 70, flexShrink: 0, textAlign: 'right',
+                color: '#555', paddingRight: 8,
+              }}>
+                +{e.ms}ms
+              </span>
+              <span style={{ color: labelColor(e.label), flexShrink: 0, marginRight: 6 }}>
+                {e.label}
+              </span>
+              <span style={{
+                color: '#888',
+                overflow: 'hidden', textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap', maxWidth: 200,
+              }}>
+                {e.detail}
+              </span>
+            </div>
+          ))}
+        </div>
+        {userScrolled && (
+          <button
+            onClick={() => setUserScrolled(false)}
+            style={{ ...sd.logBtn, marginTop: 4, width: '100%' }}
+          >↓ scroll to latest</button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -66,6 +66,7 @@ export default function VideoPlayer({
   onScrubPreviewStatus = null,
   onDebugIsPlaying = null,
   onDebugDisplayedUrl = null,
+  onDebugEvent = null,
 }) {
   const videoRef = useRef(null);
   const preloadRef = useRef(null);
@@ -85,6 +86,15 @@ export default function VideoPlayer({
   const preloadRequestIdRef = useRef(0);  // cancels stale preload fetches
 
   const displayTimeRef = useRef(null);
+
+  // DEV-only: stable ref to onDebugEvent so stable effects/callbacks can call it
+  // without listing it as a dependency. Updated whenever the prop changes.
+  const onDebugEventRef = useRef(onDebugEvent);
+  useEffect(() => { onDebugEventRef.current = onDebugEvent; }, [onDebugEvent]);
+
+  // Local ref mirror of playbackTarget for use in stable closures ([] effects).
+  const playbackTargetLocalRef = useRef(playbackTarget);
+  useEffect(() => { playbackTargetLocalRef.current = playbackTarget; }, [playbackTarget]);
 
   const [isPlaying, setIsPlaying] = useState(false);
   const [displayTime, setDisplayTime] = useState(null);
@@ -135,11 +145,16 @@ export default function VideoPlayer({
       loadingImgRef.current = null;
       if (onScrubPreviewStatus) onScrubPreviewStatus(200);
       if (onDebugDisplayedUrl) onDebugDisplayedUrl(scrubPreviewUrl);
+      if (import.meta.env.DEV) {
+        onDebugEventRef.current?.('preview 200', scrubPreviewUrl.slice(-30));
+        onDebugEventRef.current?.('preview displayed', scrubPreviewUrl.slice(-30));
+      }
     };
     img.onerror = () => {
       // Keep last good frame rather than going blank
       loadingImgRef.current = null;
       if (onScrubPreviewStatus) onScrubPreviewStatus(404);
+      if (import.meta.env.DEV) onDebugEventRef.current?.('preview 404', scrubPreviewUrl.slice(-30));
     };
 
     img.src = scrubPreviewUrl;
@@ -201,6 +216,7 @@ export default function VideoPlayer({
           video.currentTime = seekOffset;
         }
         hlsStartOffset.current = video.currentTime;
+        if (import.meta.env.DEV) onDebugEventRef.current?.('HLS manifest parsed', `seekOffset=${seekOffset}s`);
         console.log('[VIDEO] muted?', video.muted);
         video.play().then(() => {
           console.log('[VIDEO] play() success');
@@ -212,6 +228,7 @@ export default function VideoPlayer({
       hls.on(Hls.Events.ERROR, (_evt, data) => {
         console.warn('[HLS] error', data);
         if (data.fatal) {
+          if (import.meta.env.DEV) onDebugEventRef.current?.('HLS error (fatal)', `${data.type}/${data.details}`);
           setError('HLS playback error — trying fallback');
           destroyHls();
           setHlsMode(false);
@@ -352,8 +369,17 @@ export default function VideoPlayer({
     if (!video) return;
     const onPause   = () => console.log('[VIDEO] pause event');
     const onWaiting = () => console.log('[VIDEO] waiting');
-    const onStalled = () => console.log('[VIDEO] stalled');
-    const onEnded   = () => console.log('[VIDEO] ended');
+    const onStalled = () => {
+      console.log('[VIDEO] stalled');
+      if (import.meta.env.DEV) onDebugEventRef.current?.('video stalled', `src=${videoRef.current?.src?.slice(-40) ?? ''}`);
+    };
+    const onEnded = () => {
+      console.log('[VIDEO] ended');
+      if (import.meta.env.DEV) {
+        const nextId = playbackTargetLocalRef.current?.next_segment_id;
+        onDebugEventRef.current?.('video ended', `nextSegmentId=${nextId ?? 'none'}`);
+      }
+    };
     const onError   = (e) => console.log('[VIDEO] error', e);
     video.addEventListener('pause',   onPause);
     video.addEventListener('waiting', onWaiting);
@@ -407,6 +433,7 @@ export default function VideoPlayer({
           Math.abs(playbackTarget.requested_ts - preloadTargetTsRef.current) < 5
         ) {
           console.log('[HLS] preload swap — instant play');
+          if (import.meta.env.DEV) onDebugEventRef.current?.('preload swap', `ts=${playbackTarget.requested_ts}`);
 
           // Capture the preload instance BEFORE nulling refs and before destroyHls.
           // Order matters: null the preload refs first so destroyHls cannot
@@ -710,11 +737,13 @@ export default function VideoPlayer({
             if (onPlaybackStart) onPlaybackStart();
             if (onPlaybackStateChange) onPlaybackStateChange(true);
             if (onDebugIsPlaying) onDebugIsPlaying(true);
+            if (import.meta.env.DEV && onDebugEvent) onDebugEvent('video play', `absoluteTs=${displayTimeRef.current ?? 'unknown'}`);
           }}
           onPause={() => {
             setIsPlaying(false);
             if (onPlaybackStateChange) onPlaybackStateChange(false);
             if (onDebugIsPlaying) onDebugIsPlaying(false);
+            if (import.meta.env.DEV && onDebugEvent) onDebugEvent('video pause', '');
           }}
           playsInline
         />


### PR DESCRIPTION
## Summary

- Adds a fourth **EVENT LOG** panel to the DEV-only DebugTab in AdminPanel
- Timestamped state transitions fire from App.jsx and VideoPlayer.jsx into a live, scrolling log for diagnosing autoplay/preload/playback sequencing

## Design

**Zero production overhead**: All call sites are wrapped in `if (import.meta.env.DEV)`. Vite dead-code eliminates them entirely in production builds. The `registerDebugLog` / `debugEventRef` pattern means DebugTab writes its `addEntry` function into a ref once on mount — all call sites fire `ref.current?.()` with no React state updates and no re-renders.

**Stable prop identity**: `onDebugEventStable = useCallback(() => debugEventRef.current?.(), [])` is created once and passed to VideoPlayer — it never causes identity-driven re-renders.

**Stable effects in VideoPlayer**: `onDebugEventRef` keeps the received prop current inside `[]` dep effects/callbacks without adding it to their dep arrays. `playbackTargetLocalRef` mirrors the `playbackTarget` prop for use in the stable `[]` `onEnded` handler.

## Call sites

**App.jsx**: RAF preload set, RAF autoplay fired, app init, promote path (Effect A), fallback path (Effect B), handlePan/Zoom/Seek, keyboard interaction, handleCameraChange, navigateEvent, handleSegmentAdvance

**VideoPlayer.jsx**: HLS manifest parsed, HLS fatal error, preload swap, video stalled, video ended, video play/pause, preview 200/404/displayed

## Log UI

- Max 200 entries (ring buffer), auto-scroll with user-override detection
- 11 color categories keyed on label strings
- Clear / Copy buttons; "scroll to latest" affordance when user has scrolled up
- Timestamps relative to `window.__debugAppStart` (set at App.jsx module scope)

## Tests

No automated tests — this is entirely DEV-only debug instrumentation with no runtime effect in production. A TODO comment is left in AdminPanel.jsx noting the intended manual test sequence:

```
// TODO: test event log entries fire in correct order for:
//   idle → preloadTarget set → autoplay → promote path
//   idle → preload too slow → autoplay → fallback path
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)