### PR TITLE
fix: code review fixes — P1 through P3 (10 items)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,11 +375,20 @@ frigate-review-accelerator/
         preview.py            # GET /api/preview/{camera}/{ts}  <- HOT PATH
         timeline.py           # GET /api/timeline, /api/playback, /api/health
         admin.py              # GET/POST /api/admin/* (SSE log stream, script runner)
+                              # POST endpoints require X-Admin-Secret header when ADMIN_SECRET is set
+                              # POST /api/admin/reset-preview-failures
+                              #   — re-queues segments that failed preview generation
+                              #   — query params: camera (optional), since_hours (optional)
+                              #   — resets previews_generated=0 + preview_failure_reason=NULL
+                              #   — only affects segments with no row in the previews table
       services/
         indexer.py            # Filesystem walker -> segments table
         preview_generator.py  # ffmpeg frame extractor (timestamp-based, not segment-based)
         worker.py             # Background task: index -> on-demand (timestamp-driven) -> recency -> background
         event_sync.py         # Frigate event poller -> events table
+                              # Sync watermark: uses min(start_time) of fetched events,
+                              # not wall-clock now(). Falls back to now() when no events
+                              # fetched. This prevents skipping backlogged events.
         hls.py                # Frigate VOD URL construction + reachability cache
     requirements.txt
     .env                      # Not in git — copy from .env.example
@@ -450,7 +459,13 @@ This means `api.js` uses relative `/api` paths in dev — no CORS issue during l
 ```sql
 segments     — one row per Frigate MP4 segment
   id, camera, start_ts, end_ts, duration, path, file_size, indexed_at
-  previews_generated  INTEGER  0=not yet processed  1=processed once (success or failure)
+  previews_generated     INTEGER  0=not yet processed  1=processed once (success or failure)
+  preview_failure_reason TEXT     NULL on success; one of:
+                                    "timeout"            — ffmpeg timed out (60s)
+                                    "exception"          — unexpected error in subprocess call
+                                    "vaapi_decode_error" — VAAPI hardware decode failed
+                                    "ffmpeg_nonzero_exit"— ffmpeg exited non-zero (non-VAAPI)
+                                    "output_not_written" — ffmpeg returned 0 but wrote no file
 
 previews     — one row per extracted JPEG thumbnail
   id, camera, ts, segment_id, image_path, width, height
@@ -577,7 +592,20 @@ PREVIEW_RECENCY_HOURS=48
 PREVIEW_BACKGROUND_BATCH=20
 SCAN_INTERVAL_SEC=30
 CORS_ORIGINS=["http://localhost:5173"]
+ADMIN_SECRET=                         # leave empty to skip auth (WARNING logged at startup)
 ```
+
+### ADMIN_SECRET
+
+If `ADMIN_SECRET` is set to a non-empty string, all `POST /api/admin/*` endpoints
+require the caller to send `X-Admin-Secret: <value>` in the request header. A
+missing or incorrect header returns HTTP 401.
+
+If `ADMIN_SECRET` is empty or unset, the check is skipped and a WARNING is logged
+at startup: `"Admin endpoints are unauthenticated — set ADMIN_SECRET in .env"`.
+
+The `GET /api/admin/status` and `GET /api/admin/logs/stream` endpoints are not
+protected (they are read-only and carry no operational risk).
 
 -----
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,6 +53,12 @@ class Settings(BaseSettings):
     frigate_vod_enabled: bool = True
     frigate_vod_window_sec: int = 86400  # width of HLS window to request from Frigate (24 h)
 
+    # Admin endpoint authentication
+    # Set this to a non-empty string to require X-Admin-Secret header on all
+    # POST /api/admin/* endpoints. If empty, the check is skipped and a WARNING
+    # is logged at startup.
+    admin_secret: str = ""
+
     # Labels that trigger "important" flag in density buckets.
     # Phase 1: label-only rules. Phase 2 adds zone-based rules.
     # Override via IMPORTANT_LABELS='["cat","bird","bear"]' in .env

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -27,6 +27,8 @@ async def lifespan(app: FastAPI):
     log.info("  Previews:   %s", settings.preview_output_path)
     log.info("  Database:   %s", settings.database_path)
     log.info("  Frigate:    %s", settings.frigate_api_url)
+    if not settings.admin_secret:
+        log.warning("Admin endpoints are unauthenticated — set ADMIN_SECRET in .env")
 
     # Initialize database
     settings.ensure_dirs()

--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS segments (
     path        TEXT NOT NULL UNIQUE,
     file_size   INTEGER NOT NULL DEFAULT 0,
     indexed_at  REAL NOT NULL,   -- when we discovered this segment
-    previews_generated INTEGER NOT NULL DEFAULT 0  -- 0=pending, 1=done
+    previews_generated     INTEGER NOT NULL DEFAULT 0,  -- 0=pending, 1=done
+    preview_failure_reason TEXT                          -- set on ffmpeg failure, cleared on success
 );
 
 CREATE INDEX IF NOT EXISTS idx_segments_camera_time
@@ -83,12 +84,16 @@ def init_db_sync():
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size=-64000")  # 64MB cache
-    # Idempotent migration: add zones column to existing databases.
-    # New databases already have it from the SCHEMA above.
-    try:
-        conn.execute("ALTER TABLE events ADD COLUMN zones TEXT NOT NULL DEFAULT '[]'")
-    except sqlite3.OperationalError:
-        pass  # column already exists
+    # Idempotent migrations: add columns to existing databases.
+    # New databases already have these from the SCHEMA above.
+    for migration in [
+        "ALTER TABLE events ADD COLUMN zones TEXT NOT NULL DEFAULT '[]'",
+        "ALTER TABLE segments ADD COLUMN preview_failure_reason TEXT",
+    ]:
+        try:
+            conn.execute(migration)
+        except sqlite3.OperationalError:
+            pass  # column already exists
     conn.commit()
     conn.close()
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -27,13 +27,24 @@ import subprocess
 import time
 from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, Header, HTTPException
 from fastapi.responses import StreamingResponse
 
 from app.config import settings
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 log = logging.getLogger(__name__)
+
+
+def verify_admin_secret(x_admin_secret: str | None = Header(None)) -> None:
+    """FastAPI dependency — enforce X-Admin-Secret header when ADMIN_SECRET is set.
+
+    If settings.admin_secret is empty the check is skipped (with a startup
+    WARNING logged in main.py lifespan).  If it is set, any request missing
+    or providing a wrong header value receives HTTP 401.
+    """
+    if settings.admin_secret and x_admin_secret != settings.admin_secret:
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
 # Project root: backend/app/routers/ → up 3 levels
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.resolve()
@@ -128,7 +139,7 @@ async def _stream_script(
 # Endpoints
 # ---------------------------------------------------------------------------
 
-@router.post("/restart")
+@router.post("/restart", dependencies=[Depends(verify_admin_secret)])
 async def admin_restart():
     """Restart backend services via restart.sh --backend.
 
@@ -148,7 +159,7 @@ async def admin_restart():
     )
 
 
-@router.post("/update")
+@router.post("/update", dependencies=[Depends(verify_admin_secret)])
 async def admin_update():
     """Run update.sh --no-pull (deps only, assumes edits already applied).
 
@@ -166,7 +177,7 @@ async def admin_update():
     )
 
 
-@router.post("/pull")
+@router.post("/pull", dependencies=[Depends(verify_admin_secret)])
 async def admin_pull():
     """Run git pull + update.sh (full update from remote).
 
@@ -233,7 +244,7 @@ async def admin_status():
     }
 
 
-@router.post("/reindex")
+@router.post("/reindex", dependencies=[Depends(verify_admin_secret)])
 async def admin_reindex(since_hours: float = 72.0):
     """Trigger a targeted reindex from a given number of hours ago.
 
@@ -315,7 +326,54 @@ async def admin_reindex(since_hours: float = 72.0):
     )
 
 
-@router.post("/reset-scan-state")
+@router.post("/reset-preview-failures", dependencies=[Depends(verify_admin_secret)])
+async def admin_reset_preview_failures(
+    camera: str | None = None,
+    since_hours: float | None = None,
+):
+    """Re-queue segments that failed preview generation so the worker retries them.
+
+    Resets previews_generated=0 and clears preview_failure_reason for segments
+    that were processed (previews_generated=1) but have no preview in the previews
+    table — i.e., ffmpeg failed and left nothing behind.
+
+    Query params:
+      camera      — if set, only reset this camera; otherwise all cameras
+      since_hours — if set, only reset segments newer than this many hours ago
+
+    This endpoint intentionally does NOT reset segments that have a matching
+    row in the previews table — those already produced a frame successfully.
+    """
+    from app.models.database import get_db
+
+    since_ts = time.time() - (since_hours * 3600) if since_hours is not None else None
+
+    async with get_db() as db:
+        result = await db.execute(
+            """UPDATE segments
+               SET previews_generated = 0, preview_failure_reason = NULL
+               WHERE previews_generated = 1
+                 AND id NOT IN (SELECT segment_id FROM previews)
+                 AND (camera = ? OR ? IS NULL)
+                 AND (start_ts >= ? OR ? IS NULL)""",
+            (camera, camera, since_ts, since_ts),
+        )
+        await db.commit()
+        reset_count = result.rowcount
+
+    log.info(
+        "Admin: reset %d failed preview segments (camera=%s, since_hours=%s)",
+        reset_count, camera or "all", since_hours,
+    )
+    return {
+        "reset": reset_count,
+        "camera": camera,
+        "since_hours": since_hours,
+        "message": f"Reset {reset_count} failed segments — worker will retry on next cycle",
+    }
+
+
+@router.post("/reset-scan-state", dependencies=[Depends(verify_admin_secret)])
 async def admin_reset_scan_state():
     """Reset scan_state for all cameras, forcing a full rescan on next worker cycle.
 

--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -214,15 +214,19 @@ async def get_timeline(
             for r in seg_rows
         ]
 
-        # Events overlapping the range
+        # Events overlapping the range.
+        # Open events (end_ts IS NULL) are included only when their start_ts
+        # falls within 24 hours before the window start.  This prevents events
+        # that started days/weeks ago and were never closed from silently
+        # appearing in every timeline query regardless of the requested window.
         evt_rows = await db.execute_fetchall(
             """SELECT id, camera, start_ts, end_ts, label, score, has_snapshot
                FROM events
                WHERE camera = ?
-                 AND (end_ts IS NULL OR end_ts >= ?)
+                 AND ((end_ts IS NULL AND start_ts >= ? - 86400) OR end_ts >= ?)
                  AND start_ts <= ?
                ORDER BY start_ts""",
-            (camera, start, end),
+            (camera, start, start, end),
         )
 
         events = [

--- a/backend/app/services/event_sync.py
+++ b/backend/app/services/event_sync.py
@@ -98,10 +98,17 @@ def sync_frigate_events_sync(camera: str | None = None, db_path=None) -> int:
                         if not page:
                             break
                         all_events.extend(page)
-                        if len(all_events) >= 10 * _LIMIT:
+                        n = len(all_events)
+                        if n >= 5 * _LIMIT and n < 10 * _LIMIT and n // _LIMIT == 5:
+                            log.info(
+                                "Event sync for %s fetched %d events in %d pages"
+                                " — approaching pagination limit",
+                                cam, n, n // _LIMIT,
+                            )
+                        if n >= 10 * _LIMIT:
                             log.warning(
                                 "Event sync for camera %s: fetched %d events (>=%d), stopping pagination",
-                                cam, len(all_events), 10 * _LIMIT,
+                                cam, n, 10 * _LIMIT,
                             )
                             break
                         if len(page) < _LIMIT:
@@ -130,7 +137,10 @@ def sync_frigate_events_sync(camera: str | None = None, db_path=None) -> int:
                             str(evt["id"]),
                             cam,
                             float(evt.get("start_time", 0)),
-                            float(evt["end_time"]) if evt.get("end_time") is not None else None,
+                            # Explicitly check for None (not falsy) — 0.0 is a valid end_time
+                        # for instantaneous events; False would also pass this check but
+                        # indicates a malformed event from Frigate.
+                        float(evt["end_time"]) if evt.get("end_time") is not None else None,
                             str(evt.get("label", "unknown")),
                             float(evt["score"]) if evt.get("score") is not None else None,
                             int(bool(evt.get("has_clip", False))),
@@ -157,9 +167,14 @@ def sync_frigate_events_sync(camera: str | None = None, db_path=None) -> int:
                     )
                     total_synced += len(rows_to_upsert)
 
-                _write_last_sync_ts(conn, cam, now)
+                # Use the earliest start_time from fetched events as the watermark so
+                # that events arriving with a backlog (start_time < now) are not skipped
+                # on the next sync cycle.  Fall back to now only when all_events is empty
+                # (handled above in the `if not events` branch).
+                watermark = min(float(e.get("start_time", now)) for e in all_events)
+                _write_last_sync_ts(conn, cam, watermark)
                 conn.commit()
-                log.debug("Synced %d events for camera %s", len(rows_to_upsert), cam)
+                log.debug("Synced %d events for camera %s (watermark=%.0f)", len(rows_to_upsert), cam, watermark)
 
     finally:
         conn.close()

--- a/backend/app/services/hls.py
+++ b/backend/app/services/hls.py
@@ -15,8 +15,14 @@ from app.config import settings
 # ---------------------------------------------------------------------------
 # Reachability cache
 # ---------------------------------------------------------------------------
-_hls_reachable_cache: dict[str, float] = {}
+# Stores (reachable: bool, timestamp: float) tuples.
+# Positive entries (True) are kept for _HLS_CACHE_TTL_SEC seconds.
+# Negative entries (False) are kept for HLS_NEGATIVE_CACHE_TTL seconds so that
+# after a Frigate restart clients stop getting stale positive hits quickly,
+# without hammering the API on every seek.
+_hls_reachable_cache: dict[str, tuple[bool, float]] = {}
 _HLS_CACHE_TTL_SEC = 30.0
+HLS_NEGATIVE_CACHE_TTL = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -65,16 +71,23 @@ async def _resolve_hls_url(camera: str, requested_ts: float, seg_start: float) -
     if not settings.frigate_vod_enabled:
         return None
     now = _time.time()
-    if _hls_reachable_cache.get(camera, 0) + _HLS_CACHE_TTL_SEC > now:
-        # Cache hit — Frigate was reachable recently, skip the HEAD request
-        return _build_hls_url(camera, requested_ts, seg_start)
+    cached = _hls_reachable_cache.get(camera)
+    if cached is not None:
+        reachable, ts = cached
+        ttl = _HLS_CACHE_TTL_SEC if reachable else HLS_NEGATIVE_CACHE_TTL
+        if ts + ttl > now:
+            # Cache hit — return URL for positive entry, None for negative entry
+            return _build_hls_url(camera, requested_ts, seg_start) if reachable else None
     url = _build_hls_url(camera, requested_ts, seg_start)
     try:
         async with httpx.AsyncClient(timeout=2.0) as client:
             r = await client.head(url)
             if r.status_code < 300:
-                _hls_reachable_cache[camera] = now
+                _hls_reachable_cache[camera] = (True, now)
                 return url
     except Exception:
         pass
+    # Store negative result with short TTL so stale positive entries expire quickly
+    # after Frigate restarts or becomes temporarily unreachable.
+    _hls_reachable_cache[camera] = (False, now)
     return None

--- a/backend/app/services/preview_generator.py
+++ b/backend/app/services/preview_generator.py
@@ -32,6 +32,34 @@ from app.config import settings
 log = logging.getLogger(__name__)
 
 
+def _write_preview_failure_reason(segment_id: int, reason: str) -> None:
+    """Record the reason a preview extraction failed for this segment."""
+    try:
+        conn = sqlite3.connect(str(settings.database_path))
+        conn.execute(
+            "UPDATE segments SET preview_failure_reason = ? WHERE id = ?",
+            (reason, segment_id),
+        )
+        conn.commit()
+        conn.close()
+    except Exception as exc:
+        log.debug("Could not write preview_failure_reason for segment %d: %s", segment_id, exc)
+
+
+def _clear_preview_failure_reason(segment_id: int) -> None:
+    """Clear the failure reason after a successful extraction."""
+    try:
+        conn = sqlite3.connect(str(settings.database_path))
+        conn.execute(
+            "UPDATE segments SET preview_failure_reason = NULL WHERE id = ?",
+            (segment_id,),
+        )
+        conn.commit()
+        conn.close()
+    except Exception as exc:
+        log.debug("Could not clear preview_failure_reason for segment %d: %s", segment_id, exc)
+
+
 def _vaapi_device() -> str | None:
     """Return /dev/dri/renderD128 if VAAPI is available, else None."""
     device = "/dev/dri/renderD128"
@@ -175,9 +203,11 @@ def extract_preview_frame(
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
     except subprocess.TimeoutExpired:
         log.debug("Preview extraction timed out for %s ts=%.2f", camera, ts)
+        _write_preview_failure_reason(segment["id"], "timeout")
         return None
     except Exception as exc:
         log.debug("Preview extraction error for %s ts=%.2f: %s", camera, ts, exc)
+        _write_preview_failure_reason(segment["id"], "exception")
         return None
 
     # Step 4 — Return result or None
@@ -193,6 +223,7 @@ def extract_preview_frame(
                 actual_width, actual_height = _img.size
         except Exception:
             pass  # fallback to 16:9 estimate — non-fatal
+        _clear_preview_failure_reason(segment["id"])
         return {
             "ts": ts,
             "camera": camera,
@@ -205,6 +236,13 @@ def extract_preview_frame(
     log.debug("Preview extraction failed for %s ts=%.2f", camera, ts)
     if result is not None and result.stderr:
         log.debug("ffmpeg stderr: %s", result.stderr[-500:])
+    # Classify the failure reason for diagnostics
+    if result is not None and result.returncode != 0:
+        stderr_lower = (result.stderr or "").lower()
+        reason = "vaapi_decode_error" if "vaapi" in stderr_lower else "ffmpeg_nonzero_exit"
+    else:
+        reason = "output_not_written"
+    _write_preview_failure_reason(segment["id"], reason)
     return None
 
 

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -196,11 +196,9 @@ async def test_timeline_events_within_requested_range(client):
     """Events with start_ts inside the query range are returned; events entirely
     outside are not.
 
-    Also documents the NULL-end_ts edge case: an open event (end_ts IS NULL) that
-    started well before the range matches the SQL clause `(end_ts IS NULL OR
-    end_ts >= start)` and will be included by the backend. The client-side
-    post-filter in App.jsx (filteredEvents useMemo) guards against this — see
-    fix(frontend): stale events outside visible window cause spurious canvas warnings.
+    Also verifies the NULL-end_ts 24-hour cutoff: an open event that started
+    >24 hours before the window start is excluded; one that started within 24h
+    is included.
     """
     from app import config
     db_path = config.settings.database_path
@@ -212,10 +210,12 @@ async def test_timeline_events_within_requested_range(client):
     _insert_event(db_path, "evt-range-cam", range_start + 100, range_start + 200)
     # Event fully outside the range (ended before range_start)
     _insert_event(db_path, "evt-range-cam", range_start - 5000, range_start - 4000)
-    # Open event (end_ts IS NULL) that started long before the range — exposes
-    # the NULL-end_ts inclusion bug; this event WILL be returned by the current
-    # backend because (end_ts IS NULL) satisfies the overlap condition.
+    # Open event (end_ts IS NULL) that started >24h before range_start (~50h ago).
+    # Must be EXCLUDED by the backend's 24h cutoff.
     _insert_event(db_path, "evt-range-cam", range_start - 180000, end_ts=None)
+    # Open event (end_ts IS NULL) that started within 24h of range_start (~1h ago).
+    # Must be INCLUDED because it may still be ongoing at the window start.
+    _insert_event(db_path, "evt-range-cam", range_start - 3600, end_ts=None)
 
     resp = await client.get(
         "/api/timeline",
@@ -234,18 +234,14 @@ async def test_timeline_events_within_requested_range(client):
     assert range_start - 5000 not in returned_start_ts, (
         "Event that ended before range_start must not be returned"
     )
-    # The NULL-end_ts event from 50h ago — document that the backend returns it.
-    # The client-side filteredEvents post-filter in App.jsx is the guardrail.
-    null_end_included = (range_start - 180000) in returned_start_ts
-    # We do not assert False here because this is a known backend behaviour;
-    # instead we leave a clear signal in the test output.
-    if null_end_included:
-        import warnings
-        warnings.warn(
-            "Backend includes NULL-end_ts events starting outside the requested range. "
-            "The client-side filteredEvents post-filter in App.jsx is the active guardrail. "
-            "TODO: fix backend: add a bounded cutoff for open events in timeline.py."
-        )
+    # Open event from >24h ago must be EXCLUDED (24h cutoff fix)
+    assert range_start - 180000 not in returned_start_ts, (
+        "Open event starting >24h before window start must be excluded by the backend cutoff"
+    )
+    # Open event from within 24h of range_start must be INCLUDED
+    assert range_start - 3600 in returned_start_ts, (
+        "Open event starting within 24h of window start must be included"
+    )
 
 
 async def test_timeline_returns_events_outside_tight_range_when_padded(client):

--- a/backend/tests/integration/test_playback_hls.py
+++ b/backend/tests/integration/test_playback_hls.py
@@ -132,6 +132,75 @@ async def test_segment_info_not_found(client):
 
 
 # ---------------------------------------------------------------------------
+# Negative reachability cache TTL
+# ---------------------------------------------------------------------------
+
+async def test_negative_cache_stored_on_failure(monkeypatch):
+    """A failed reachability check stores a (False, timestamp) tuple in the cache."""
+    from app.services import hls as hls_mod
+
+    # Ensure the camera is not already cached
+    hls_mod._hls_reachable_cache.pop("neg-ttl-cam", None)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.head = AsyncMock(side_effect=httpx.ConnectError("down"))
+
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
+        result = await hls_mod._resolve_hls_url("neg-ttl-cam", 1700000000.0, 1699999990.0)
+
+    assert result is None
+    cached = hls_mod._hls_reachable_cache.get("neg-ttl-cam")
+    assert cached is not None, "Failed check must be stored in the cache"
+    reachable, ts = cached
+    assert reachable is False, "Negative cache entry must have reachable=False"
+
+
+async def test_negative_cache_returns_none_within_ttl(monkeypatch):
+    """Within the negative TTL, _resolve_hls_url returns None without a HEAD request."""
+    import time
+    from app.services import hls as hls_mod
+
+    # Inject a fresh negative cache entry
+    hls_mod._hls_reachable_cache["neg-hit-cam"] = (False, time.time())
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.head = AsyncMock()
+
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
+        result = await hls_mod._resolve_hls_url("neg-hit-cam", 1700000000.0, 1699999990.0)
+
+    assert result is None
+    mock_client.head.assert_not_called()  # no HEAD request during negative TTL
+
+
+async def test_positive_cache_entry_format(monkeypatch):
+    """A successful check stores a (True, timestamp) tuple in the cache."""
+    from app.services import hls as hls_mod
+
+    hls_mod._hls_reachable_cache.pop("pos-fmt-cam", None)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.head = AsyncMock(return_value=mock_response)
+
+    with patch("app.services.hls.httpx.AsyncClient", return_value=mock_client):
+        result = await hls_mod._resolve_hls_url("pos-fmt-cam", 1700000000.0, 1699999990.0)
+
+    assert result is not None
+    cached = hls_mod._hls_reachable_cache.get("pos-fmt-cam")
+    assert cached is not None
+    reachable, ts = cached
+    assert reachable is True, "Positive cache entry must have reachable=True"
+
+
+# ---------------------------------------------------------------------------
 # HLS window is at least 86000 seconds wide (24-hour default)
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/test_preview_generator_v2.py
+++ b/backend/tests/unit/test_preview_generator_v2.py
@@ -163,7 +163,14 @@ class TestExtractPreviewFrame:
         assert frame["ts"] == pytest.approx(ts)
 
     def test_uses_provided_segment(self, tmp_path, monkeypatch):
-        """When segment is provided, sqlite3.connect is never called."""
+        """When segment is provided, sqlite3.connect is NOT called for segment lookup.
+
+        On success, _clear_preview_failure_reason does call sqlite3.connect once
+        (to clear any stale failure reason), but that is NOT a segment-lookup call.
+        The invariant enforced here is: no segment lookup happens when segment is
+        pre-provided. We verify this by inspecting that no SELECT FROM segments
+        was executed.
+        """
         recordings = tmp_path / "recordings"
         previews = tmp_path / "previews"
         recordings.mkdir()
@@ -190,7 +197,16 @@ class TestExtractPreviewFrame:
                     camera="cam", ts=1700000004.0, width=320, quality=5, segment=segment,
                 )
 
-        mock_connect.assert_not_called()
+        # On success, connect is called exactly once — for _clear_preview_failure_reason,
+        # NOT for a segment lookup. Verify no SELECT FROM segments was executed.
+        executed_queries = [
+            call_args[0][0]
+            for call_args in mock_connect.return_value.execute.call_args_list
+        ]
+        assert not any("SELECT" in q for q in executed_queries), (
+            "sqlite3.connect must not be used for segment lookup when segment is pre-provided; "
+            f"found queries: {executed_queries}"
+        )
 
     def test_stores_actual_dimensions_not_assumed_16x9(self, tmp_path, monkeypatch):
         """Actual file dimensions are used, not hardcoded 16:9."""

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -343,10 +343,13 @@ export default function App() {
   const latestCameraTsRef = useRef(null);
   useEffect(() => { latestCameraTsRef.current = latestCameraTs; }, [latestCameraTs]);
   // preloadRequestRef: incremented on interaction to cancel in-flight preload fetches.
+  // abortControllerRef: AbortController for the in-flight idle preload network request.
+  //   Aborted on interaction (via preloadRequestRef++) and on component unmount.
   // idlePreloadStartedRef: prevents re-firing preload within the same idle window.
   // TODO: test preload cancel — preloadRequestRef increment on interaction discards
   // stale fetchPlaybackTarget responses.
   const preloadRequestRef = useRef(0);
+  const abortControllerRef = useRef(null);
   const idlePreloadStartedRef = useRef(false);
   // nearEventCacheRef: sorted filteredEvents + next upcoming event ahead of cursor.
   // Updated by useEffect on filteredEvents (infrequent); re-searched inside setCursorTs.
@@ -381,7 +384,11 @@ export default function App() {
         const ts = cursorTsRef.current;
         const cam = selectedCameraRef.current;
         if (cam && ts != null) {
-          fetchPlaybackTarget(cam, ts)
+          // Abort any in-flight preload network request before issuing a new one.
+          abortControllerRef.current?.abort();
+          abortControllerRef.current = new AbortController();
+          const signal = abortControllerRef.current.signal;
+          fetchPlaybackTarget(cam, ts, { signal })
             .then(target => {
               if (myId !== preloadRequestRef.current) return; // cancelled by interaction
               if (target) {
@@ -389,7 +396,10 @@ export default function App() {
                 if (import.meta.env.DEV) debugEventRef.current?.('preloadTarget set', `ts=${target.requested_ts}, hls=${target.hls_url ? 'ready' : 'none'}`);
               }
             })
-            .catch((e) => { console.warn('[RAF] idle preload fetch failed:', e.message); });
+            .catch((e) => {
+              if (e.name === 'AbortError') return; // cancelled — not an error
+              console.warn('[RAF] idle preload fetch failed:', e.message);
+            });
         }
       }
 
@@ -463,6 +473,7 @@ export default function App() {
     autoplayRafRef.current = requestAnimationFrame(tick);
     return () => {
       if (autoplayRafRef.current) cancelAnimationFrame(autoplayRafRef.current);
+      abortControllerRef.current?.abort();
     };
   }, []); // stable — all values read from refs
 
@@ -581,12 +592,9 @@ export default function App() {
   const filteredEvents = useMemo(() => {
     if (!timelineData?.events) return [];
     // Post-filter: drop events whose start_ts falls outside the current visible window.
-    // Defense-in-depth guard against NULL-end_ts events from the backend:
-    // the SQL clause `(end_ts IS NULL OR end_ts >= start)` includes open/incomplete
-    // events regardless of how old they are, producing start_ts values 50+ hours
-    // before the visible window. The primary fix belongs in the backend query, but
-    // this guard ensures stale events never reach the canvas or navigation logic.
-    // TODO: fix backend: replace NULL-end_ts open condition with a bounded cutoff.
+    // Defense-in-depth guard: the backend applies a 24h cutoff for open events but
+    // this client-side filter provides an additional layer ensuring stale events
+    // never reach the canvas or navigation logic regardless of backend behaviour.
     const inWindow = timelineData.events.filter(
       e => e.start_ts >= rangeStart - rangeSec && e.start_ts <= rangeEnd + rangeSec
     );

--- a/frontend/src/components/Timeline.jsx
+++ b/frontend/src/components/Timeline.jsx
@@ -28,6 +28,7 @@
 
 import { useRef, useEffect, useState, useCallback } from 'react';
 import { formatTimeShort, clampTs } from '../utils/time.js';
+import { ICON_PATHS, buildIconCache } from '../utils/icons.js';
 
 const TIMELINE_HEIGHT = 100;
 const HEATMAP_Y = 0;
@@ -56,48 +57,17 @@ const EVENT_COLORS = {
   default:    '#607D8B',
 };
 
-// ─── Icon map: same set as VerticalTimeline (keep in sync) ──────────────────
-const ICON_PATHS = {
-  person:     `<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>`,
-  car:        `<path d="M19 17h2c.6 0 1-.4 1-1v-3c0-.9-.7-1.7-1.5-1.9C18.7 10.6 16 10 16 10s-1.3-1.4-2.2-2.3c-.5-.4-1.1-.7-1.8-.7H5c-.6 0-1.1.4-1.4.9l-1.4 2.9A3.7 3.7 0 0 0 2 12v4c0 .6.4 1 1 1h2"/><circle cx="7" cy="17" r="2"/><path d="M9 17h6"/><circle cx="17" cy="17" r="2"/>`,
-  truck:      `<path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/>`,
-  motorcycle: `<path d="m18 14-1-3"/><path d="m3 9 6 2a2 2 0 0 1 2-2h2a2 2 0 0 1 1.99 1.81"/><path d="M8 17h3a1 1 0 0 0 1-1 6 6 0 0 1 6-6 1 1 0 0 0 1-1v-.75A5 5 0 0 0 17 5"/><circle cx="19" cy="17" r="3"/><circle cx="5" cy="17" r="3"/>`,
-  bicycle:    `<circle cx="18.5" cy="17.5" r="3.5"/><circle cx="5.5" cy="17.5" r="3.5"/><circle cx="15" cy="5" r="1"/><path d="M12 17.5V14l-3-3 4-3 2 3h2"/>`,
-  dog:        `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  cat:        `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  bird:       `<path d="M16 7h.01"/><path d="M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20"/><path d="m20 7 2 .5-2 .5"/><path d="M10 18v3"/><path d="M14 17.75V21"/><path d="M7 18a6 6 0 0 0 3.84-10.61"/>`,
-  horse:      `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  bear:       `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  deer:       `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  package:    `<path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><polyline points="3.29 7 12 12 20.71 7"/><path d="m7.5 4.27 9 5.15"/>`,
-};
-
+// Pre-render each (label, color) into an offscreen 12×12 canvas.
+// Async SVG→Image load; canvas is blank until onload fires. After all icons
+// load, any registered drawCanvas callbacks are fired for a final repaint.
+// ICON_PATHS and buildIconCache are shared with VerticalTimeline.jsx via icons.js.
 const _tlRedrawCallbacks = new Set();
-let _tlIconsLoaded = 0;
-const _TL_ICON_TARGET = Object.keys(ICON_PATHS).length;
 
-function buildIconCanvas(svgPathData, color, size = 12) {
-  const oc = document.createElement('canvas');
-  oc.width = size;
-  oc.height = size;
-  const ctx = oc.getContext('2d');
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${svgPathData}</svg>`;
-  const img = new Image();
-  img.src = 'data:image/svg+xml,' + encodeURIComponent(svg);
-  img.onload = () => {
-    ctx.drawImage(img, 0, 0);
-    _tlIconsLoaded++;
-    if (_tlIconsLoaded >= _TL_ICON_TARGET) {
-      for (const cb of _tlRedrawCallbacks) cb();
-    }
-  };
-  return oc;
-}
-
-const ICON_CACHE = new Map();
-for (const [label, pathData] of Object.entries(ICON_PATHS)) {
-  ICON_CACHE.set(label, buildIconCanvas(pathData, EVENT_COLORS[label] ?? EVENT_COLORS.default, 12));
-}
+const ICON_CACHE = buildIconCache(
+  ICON_PATHS,
+  label => EVENT_COLORS[label] ?? EVENT_COLORS.default,
+  () => { for (const cb of _tlRedrawCallbacks) cb(); },
+);
 
 const DRAG_THRESHOLD_PX = 3;
 

--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -34,6 +34,7 @@
 import { useRef, useEffect, useState, useCallback, useMemo } from 'react';
 import { formatTimeShort, formatTime, clampTs } from '../utils/time.js';
 import { RETICLE_FRACTION } from '../utils/constants.js';
+import { ICON_PATHS, buildIconCache } from '../utils/icons.js';
 
 function useDebounce(fn, delay) {
   const timer = useRef(null);
@@ -104,56 +105,17 @@ const EVENT_COLORS = {
   default:    '#ffcc00',
 };
 
-// ─── Icon map: Lucide SVG elements keyed by Frigate label ───────────────────
-// Unlisted labels ("face", "fire", "license_plate", etc.) silently produce no
-// icon — no text fallback, no placeholder, no console warning.
-// TODO: add frontend test — ICON_CACHE populated at module init,
-// unknown labels ("face", "fire", "license_plate") produce no icon
-// and no console warning.
-const ICON_PATHS = {
-  person:     `<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>`,
-  car:        `<path d="M19 17h2c.6 0 1-.4 1-1v-3c0-.9-.7-1.7-1.5-1.9C18.7 10.6 16 10 16 10s-1.3-1.4-2.2-2.3c-.5-.4-1.1-.7-1.8-.7H5c-.6 0-1.1.4-1.4.9l-1.4 2.9A3.7 3.7 0 0 0 2 12v4c0 .6.4 1 1 1h2"/><circle cx="7" cy="17" r="2"/><path d="M9 17h6"/><circle cx="17" cy="17" r="2"/>`,
-  truck:      `<path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/>`,
-  motorcycle: `<path d="m18 14-1-3"/><path d="m3 9 6 2a2 2 0 0 1 2-2h2a2 2 0 0 1 1.99 1.81"/><path d="M8 17h3a1 1 0 0 0 1-1 6 6 0 0 1 6-6 1 1 0 0 0 1-1v-.75A5 5 0 0 0 17 5"/><circle cx="19" cy="17" r="3"/><circle cx="5" cy="17" r="3"/>`,
-  bicycle:    `<circle cx="18.5" cy="17.5" r="3.5"/><circle cx="5.5" cy="17.5" r="3.5"/><circle cx="15" cy="5" r="1"/><path d="M12 17.5V14l-3-3 4-3 2 3h2"/>`,
-  dog:        `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  cat:        `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  bird:       `<path d="M16 7h.01"/><path d="M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20"/><path d="m20 7 2 .5-2 .5"/><path d="M10 18v3"/><path d="M14 17.75V21"/><path d="M7 18a6 6 0 0 0 3.84-10.61"/>`,
-  horse:      `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  bear:       `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  deer:       `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
-  package:    `<path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><polyline points="3.29 7 12 12 20.71 7"/><path d="m7.5 4.27 9 5.15"/>`,
-};
-
 // Pre-render each (label, color) into an offscreen 12×12 canvas.
 // Async SVG→Image load; canvas is blank until onload fires. After all icons
 // load, any registered drawCanvas callbacks are fired for a final repaint.
+// ICON_PATHS and buildIconCache are shared with Timeline.jsx via icons.js.
 const _vtRedrawCallbacks = new Set();
-let _vtIconsLoaded = 0;
-const _VT_ICON_TARGET = Object.keys(ICON_PATHS).length;
 
-function buildIconCanvas(svgPathData, color, size = 12) {
-  const oc = document.createElement('canvas');
-  oc.width = size;
-  oc.height = size;
-  const ctx = oc.getContext('2d');
-  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${svgPathData}</svg>`;
-  const img = new Image();
-  img.src = 'data:image/svg+xml,' + encodeURIComponent(svg);
-  img.onload = () => {
-    ctx.drawImage(img, 0, 0);
-    _vtIconsLoaded++;
-    if (_vtIconsLoaded >= _VT_ICON_TARGET) {
-      for (const cb of _vtRedrawCallbacks) cb();
-    }
-  };
-  return oc;
-}
-
-const ICON_CACHE = new Map();
-for (const [label, pathData] of Object.entries(ICON_PATHS)) {
-  ICON_CACHE.set(label, buildIconCanvas(pathData, EVENT_COLORS[label] ?? EVENT_COLORS.default, 12));
-}
+const ICON_CACHE = buildIconCache(
+  ICON_PATHS,
+  label => EVENT_COLORS[label] ?? EVENT_COLORS.default,
+  () => { for (const cb of _vtRedrawCallbacks) cb(); },
+);
 
 /** HH:MM format for tick labels — no AM/PM suffix, no seconds. */
 function formatHHMM(ts, timeFormat) {

--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -450,6 +450,7 @@ export default function VideoPlayer({
           // before use. Without detachMedia() + attachMedia(video), the Hls instance
           // will play silently into the hidden element and the user sees a frozen
           // screen with no error. This step is non-negotiable.
+          preloadHls.stopLoad();
           preloadHls.detachMedia();
           preloadHls.attachMedia(video);
 

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -46,12 +46,12 @@ export async function fetchPreviewStrip(camera, startTs, endTs, maxFrames = 300,
  * Backend resolves timestamp → segment + offset.
  * Returns: { segment_id, offset_sec, stream_url, next_segment_id, ... }
  */
-export async function fetchPlaybackTarget(camera, ts) {
+export async function fetchPlaybackTarget(camera, ts, options = {}) {
   const params = new URLSearchParams({
     camera,
     ts: String(ts),
   });
-  return apiFetch(`/playback?${params}`);
+  return apiFetch(`/playback?${params}`, options);
 }
 
 /**

--- a/frontend/src/utils/icons.js
+++ b/frontend/src/utils/icons.js
@@ -1,0 +1,74 @@
+/**
+ * Shared icon utilities for Timeline and VerticalTimeline canvas rendering.
+ *
+ * ICON_PATHS — Lucide SVG path data keyed by Frigate event label.
+ *   Unlisted labels ("face", "fire", "license_plate", etc.) silently produce
+ *   no icon — no text fallback, no placeholder, no console warning.
+ *
+ * buildIconCanvas — render a single SVG icon to an offscreen canvas.
+ *
+ * buildIconCache — construct a Map<label, HTMLCanvasElement> for a full label
+ *   set. Accepts a callback that fires once all async SVG→Image loads complete,
+ *   enabling each canvas component to schedule a final repaint.
+ *
+ * TODO: add frontend test — ICON_CACHE populated at module init,
+ * unknown labels ("face", "fire", "license_plate") produce no icon and no
+ * console warning.
+ */
+
+export const ICON_PATHS = {
+  person:     `<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>`,
+  car:        `<path d="M19 17h2c.6 0 1-.4 1-1v-3c0-.9-.7-1.7-1.5-1.9C18.7 10.6 16 10 16 10s-1.3-1.4-2.2-2.3c-.5-.4-1.1-.7-1.8-.7H5c-.6 0-1.1.4-1.4.9l-1.4 2.9A3.7 3.7 0 0 0 2 12v4c0 .6.4 1 1 1h2"/><circle cx="7" cy="17" r="2"/><path d="M9 17h6"/><circle cx="17" cy="17" r="2"/>`,
+  truck:      `<path d="M14 18V6a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v11a1 1 0 0 0 1 1h2"/><path d="M15 18H9"/><path d="M19 18h2a1 1 0 0 0 1-1v-3.65a1 1 0 0 0-.22-.624l-3.48-4.35A1 1 0 0 0 17.52 8H14"/><circle cx="17" cy="18" r="2"/><circle cx="7" cy="18" r="2"/>`,
+  motorcycle: `<path d="m18 14-1-3"/><path d="m3 9 6 2a2 2 0 0 1 2-2h2a2 2 0 0 1 1.99 1.81"/><path d="M8 17h3a1 1 0 0 0 1-1 6 6 0 0 1 6-6 1 1 0 0 0 1-1v-.75A5 5 0 0 0 17 5"/><circle cx="19" cy="17" r="3"/><circle cx="5" cy="17" r="3"/>`,
+  bicycle:    `<circle cx="18.5" cy="17.5" r="3.5"/><circle cx="5.5" cy="17.5" r="3.5"/><circle cx="15" cy="5" r="1"/><path d="M12 17.5V14l-3-3 4-3 2 3h2"/>`,
+  dog:        `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
+  cat:        `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
+  bird:       `<path d="M16 7h.01"/><path d="M3.4 18H12a8 8 0 0 0 8-8V7a4 4 0 0 0-7.28-2.3L2 20"/><path d="m20 7 2 .5-2 .5"/><path d="M10 18v3"/><path d="M14 17.75V21"/><path d="M7 18a6 6 0 0 0 3.84-10.61"/>`,
+  horse:      `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
+  bear:       `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
+  deer:       `<circle cx="11" cy="4" r="2"/><circle cx="18" cy="8" r="2"/><circle cx="20" cy="16" r="2"/><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z"/>`,
+  package:    `<path d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"/><path d="M12 22V12"/><polyline points="3.29 7 12 12 20.71 7"/><path d="m7.5 4.27 9 5.15"/>`,
+};
+
+/**
+ * Render a single Lucide SVG icon into an offscreen 12×12 canvas.
+ *
+ * The canvas is returned immediately (blank until the async SVG→Image load
+ * fires). Call onLoad to be notified when the pixel data is ready.
+ */
+export function buildIconCanvas(svgPathData, color, size = 12, onLoad = null) {
+  const oc = document.createElement('canvas');
+  oc.width = size;
+  oc.height = size;
+  const ctx = oc.getContext('2d');
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="${color}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${svgPathData}</svg>`;
+  const img = new Image();
+  img.src = 'data:image/svg+xml,' + encodeURIComponent(svg);
+  img.onload = () => {
+    ctx.drawImage(img, 0, 0);
+    if (onLoad) onLoad();
+  };
+  return oc;
+}
+
+/**
+ * Build a Map<label, HTMLCanvasElement> for a full icon set.
+ *
+ * @param {Object} iconPaths  - ICON_PATHS (or a subset)
+ * @param {Function} getColor - (label: string) => CSS color string
+ * @param {Function} onAllLoaded - called once when all async loads complete
+ * @returns {Map<string, HTMLCanvasElement>}
+ */
+export function buildIconCache(iconPaths, getColor, onAllLoaded) {
+  const cache = new Map();
+  let loaded = 0;
+  const target = Object.keys(iconPaths).length;
+  for (const [label, pathData] of Object.entries(iconPaths)) {
+    cache.set(label, buildIconCanvas(pathData, getColor(label), 12, () => {
+      loaded++;
+      if (loaded >= target) onAllLoaded();
+    }));
+  }
+  return cache;
+}


### PR DESCRIPTION
## Summary

Ten code-review fixes across P1 (critical), P2 (notable), and P3 (quality).

### P1 — Critical

- **VideoPlayer.jsx**: Add `preloadHls.stopLoad()` immediately before `detachMedia()` in the HLS preload swap path. Prevents hls.js state corruption when a fragment is downloading at the moment of the swap.
- **preview_failure_reason column**: DB migration adds `preview_failure_reason TEXT` to `segments`. `extract_preview_frame` writes the reason on ffmpeg failure (`timeout`, `exception`, `vaapi_decode_error`, `ffmpeg_nonzero_exit`, `output_not_written`) and clears to NULL on success.
- **POST /api/admin/reset-preview-failures**: Re-queues failed segments (`previews_generated=1`, no row in `previews`) for worker retry. Accepts optional `camera` and `since_hours` query params.
- **Admin authentication**: `ADMIN_SECRET` config setting + `verify_admin_secret` FastAPI dependency on all `POST /api/admin/*` endpoints. WARNING logged at startup when unset.
- **AbortController for idle preload**: `abortControllerRef` in App.jsx aborts any in-flight `fetchPlaybackTarget` network request before each new preload fetch and on component unmount. `fetchPlaybackTarget` in `api.js` now accepts an `options` argument. `AbortError` is handled gracefully (silent ignore).

### P2 — Notable

- **Event sync watermark**: `_write_last_sync_ts` now uses `min(start_time)` of fetched events instead of wall-clock `now()`, preventing backlogged events from being skipped on the next cycle.
- **NULL-end_ts 24h cutoff**: Timeline SQL changed from `(end_ts IS NULL OR end_ts >= ?)` to `((end_ts IS NULL AND start_ts >= ? - 86400) OR end_ts >= ?)`. Open events starting >24 hours before the window start are excluded. The frontend `filteredEvents` TODO comment is updated to reflect this is no longer the sole guardrail.
- **HLS negative cache TTL**: `_hls_reachable_cache` now stores `(bool, timestamp)` tuples. Failed reachability checks are stored with `HLS_NEGATIVE_CACHE_TTL = 5s` so stale positive hits expire quickly after Frigate restarts.

### P3 — Code quality

- **icons.js extraction**: `ICON_PATHS`, `buildIconCanvas`, and `buildIconCache` extracted to `frontend/src/utils/icons.js`. Both `Timeline.jsx` and `VerticalTimeline.jsx` import from there — ~60 lines of duplicate constant data removed from each.
- **event_sync.py**: Strengthen `end_time=0` comment (explains `None` vs falsy). Add INFO log at `5 * _LIMIT` (500 events) approaching pagination limit, before the existing WARNING at `10 * _LIMIT`.

## Test plan

- [x] 156 backend tests pass (`pytest tests/ -q`)
- [x] Updated `test_api.py`: asserts old NULL-end_ts behaviour gone, new 24h cutoff works
- [x] Updated `test_playback_hls.py`: 3 new tests for negative cache TTL (store on failure, return None within TTL, positive entry format)
- [x] Updated `test_preview_generator_v2.py`: `test_uses_provided_segment` updated — allows the new DB write for `_clear_preview_failure_reason` on success but asserts no `SELECT FROM segments` (segment lookup still bypassed when pre-provided)
- [ ] Frontend canvas rendering tests not possible — no test harness exists yet (existing TODOs left in place)

🤖 Generated with [Claude Code](https://claude.com/claude-code)