### PR TITLE
fix(worker): retry transient preview failures up to MAX_RETRIES before suppressing

### DIFF
--- a/backend/app/models/database.py
+++ b/backend/app/models/database.py
@@ -26,7 +26,8 @@ CREATE TABLE IF NOT EXISTS segments (
     file_size   INTEGER NOT NULL DEFAULT 0,
     indexed_at  REAL NOT NULL,   -- when we discovered this segment
     previews_generated     INTEGER NOT NULL DEFAULT 0,  -- 0=pending, 1=done
-    preview_failure_reason TEXT                          -- set on ffmpeg failure, cleared on success
+    preview_failure_reason TEXT,                         -- set on ffmpeg failure, cleared on success
+    retry_count            INTEGER NOT NULL DEFAULT 0   -- incremented on each failure; capped at MAX_RETRIES
 );
 
 CREATE INDEX IF NOT EXISTS idx_segments_camera_time
@@ -89,6 +90,7 @@ def init_db_sync():
     for migration in [
         "ALTER TABLE events ADD COLUMN zones TEXT NOT NULL DEFAULT '[]'",
         "ALTER TABLE segments ADD COLUMN preview_failure_reason TEXT",
+        "ALTER TABLE segments ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0",
     ]:
         try:
             conn.execute(migration)

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -351,7 +351,9 @@ async def admin_reset_preview_failures(
     async with get_db() as db:
         result = await db.execute(
             """UPDATE segments
-               SET previews_generated = 0, preview_failure_reason = NULL
+               SET previews_generated = 0,
+                   preview_failure_reason = NULL,
+                   retry_count = 0
                WHERE previews_generated = 1
                  AND id NOT IN (SELECT segment_id FROM previews)
                  AND (camera = ? OR ? IS NULL)

--- a/backend/app/services/worker.py
+++ b/backend/app/services/worker.py
@@ -44,6 +44,13 @@ _worker_task: asyncio.Task | None = None
 # At scan_interval_sec=30 and BACKGROUND_INTERVAL=3, that's every ~90 seconds.
 BACKGROUND_INTERVAL = 3
 
+# Maximum number of failed extraction attempts before a segment is permanently
+# suppressed from the preview queue (previews_generated set to 1 on the
+# MAX_RETRIES-th failure). Transient errors (VAAPI spike, I/O blip) recover
+# within this many worker cycles. Permanently broken segments (corrupt file,
+# missing recording) are suppressed after MAX_RETRIES attempts.
+MAX_RETRIES = 3
+
 # On-demand queue: (camera, bucket_ts) pairs pushed by the preview router
 # when the frontend signals which timestamps it needs right now.
 _demand_queue: deque[tuple[str, float]] = deque(maxlen=50)
@@ -147,10 +154,26 @@ async def _run_recency_pass(limit: int = 50) -> int:
                     (frame["camera"], frame["ts"], frame["segment_id"],
                      frame["image_path"], frame["width"], frame["height"]),
                 )
-            await db.execute(
-                "UPDATE segments SET previews_generated = 1 WHERE id = ?",
-                (segment["id"],),
-            )
+                await db.execute(
+                    "UPDATE segments SET previews_generated = 1 WHERE id = ?",
+                    (segment["id"],),
+                )
+            else:
+                # Increment retry_count. On the MAX_RETRIES-th failure set
+                # previews_generated=1 to remove the segment from the queue so
+                # it does not consume worker budget indefinitely. The CASE uses
+                # the pre-update value of retry_count (SQLite evaluates SET
+                # expressions against the old row).
+                await db.execute(
+                    """UPDATE segments
+                       SET retry_count = retry_count + 1,
+                           previews_generated = CASE
+                               WHEN retry_count + 1 >= ? THEN 1
+                               ELSE 0
+                           END
+                       WHERE id = ?""",
+                    (MAX_RETRIES, segment["id"]),
+                )
             await db.commit()
         processed += 1
 
@@ -201,10 +224,21 @@ async def _run_background_pass(limit: int = 20) -> int:
                     (frame["camera"], frame["ts"], frame["segment_id"],
                      frame["image_path"], frame["width"], frame["height"]),
                 )
-            await db.execute(
-                "UPDATE segments SET previews_generated = 1 WHERE id = ?",
-                (segment["id"],),
-            )
+                await db.execute(
+                    "UPDATE segments SET previews_generated = 1 WHERE id = ?",
+                    (segment["id"],),
+                )
+            else:
+                await db.execute(
+                    """UPDATE segments
+                       SET retry_count = retry_count + 1,
+                           previews_generated = CASE
+                               WHEN retry_count + 1 >= ? THEN 1
+                               ELSE 0
+                           END
+                       WHERE id = ?""",
+                    (MAX_RETRIES, segment["id"]),
+                )
             await db.commit()
         processed += 1
 
@@ -279,10 +313,21 @@ async def _process_scheduler_jobs(jobs: list) -> int:
                         (frame["camera"], frame["ts"], frame["segment_id"],
                          frame["image_path"], frame["width"], frame["height"]),
                     )
-                await db.execute(
-                    "UPDATE segments SET previews_generated = 1 WHERE id = ?",
-                    (segment["id"],),
-                )
+                    await db.execute(
+                        "UPDATE segments SET previews_generated = 1 WHERE id = ?",
+                        (segment["id"],),
+                    )
+                else:
+                    await db.execute(
+                        """UPDATE segments
+                           SET retry_count = retry_count + 1,
+                               previews_generated = CASE
+                                   WHEN retry_count + 1 >= ? THEN 1
+                                   ELSE 0
+                               END
+                           WHERE id = ?""",
+                        (MAX_RETRIES, segment["id"]),
+                    )
                 await db.commit()
                 processed += 1
 

--- a/backend/tests/integration/test_api.py
+++ b/backend/tests/integration/test_api.py
@@ -675,3 +675,103 @@ async def test_worker_scheduler_jobs_row_name_access(test_app, monkeypatch):
     assert called_with["start_ts"] == pytest.approx(1700000000.0)
     assert called_with["end_ts"] == pytest.approx(1700000010.0)
     assert called_with["duration"] == pytest.approx(10.0)
+
+
+# ---------------------------------------------------------------------------
+# Worker retry logic — previews_generated stays 0 until MAX_RETRIES
+# ---------------------------------------------------------------------------
+
+async def test_recency_pass_does_not_suppress_until_max_retries(test_app, monkeypatch):
+    """A segment with extract_preview_frame=None stays previews_generated=0
+    until retry_count reaches MAX_RETRIES, then gets previews_generated=1.
+
+    Uses a real in-process SQLite DB (via test_app fixture) and drives
+    _run_recency_pass directly, mocking only extract_preview_frame.
+    """
+    import sqlite3
+    from app import config
+    from app.services.worker import _run_recency_pass, MAX_RETRIES
+
+    monkeypatch.setattr("app.services.worker.extract_preview_frame", lambda **kw: None)
+
+    db_path = config.settings.database_path
+    # Use a recent timestamp so the segment falls within the recency window
+    recent_ts = time.time() - 60  # 1 minute ago
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """INSERT INTO segments
+           (camera, start_ts, end_ts, duration, path, file_size, indexed_at, previews_generated, retry_count)
+           VALUES (?, ?, ?, ?, ?, 1024, ?, 0, 0)""",
+        ("retry-cam", recent_ts, recent_ts + 10.0, 10.0, "retry-cam/retry.mp4", time.time()),
+    )
+    conn.commit()
+    seg_id = conn.execute(
+        "SELECT id FROM segments WHERE camera = 'retry-cam'"
+    ).fetchone()[0]
+    conn.close()
+
+    # Each pass increments retry_count; previews_generated stays 0 until MAX_RETRIES-1
+    for attempt in range(1, MAX_RETRIES):
+        await _run_recency_pass(limit=10)
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT previews_generated, retry_count FROM segments WHERE id = ?", (seg_id,)
+        ).fetchone()
+        conn.close()
+        assert row[1] == attempt, f"retry_count should be {attempt} after attempt {attempt}"
+        assert row[0] == 0, (
+            f"previews_generated must stay 0 before MAX_RETRIES (attempt {attempt})"
+        )
+
+    # Final attempt — should hit MAX_RETRIES and set previews_generated=1
+    await _run_recency_pass(limit=10)
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT previews_generated, retry_count FROM segments WHERE id = ?", (seg_id,)
+    ).fetchone()
+    conn.close()
+    assert row[1] == MAX_RETRIES, f"retry_count should be {MAX_RETRIES} after final attempt"
+    assert row[0] == 1, "previews_generated must be 1 after MAX_RETRIES failures"
+
+
+async def test_admin_reset_preview_failures_zeroes_retry_count(client, test_app):
+    """POST /api/admin/reset-preview-failures must reset retry_count to 0.
+
+    Inserts a segment with previews_generated=1, retry_count=MAX_RETRIES, and no
+    matching preview row.  After the reset call the segment should have
+    previews_generated=0 and retry_count=0 so the worker will retry it.
+    """
+    import sqlite3
+    from app import config
+    from app.services.worker import MAX_RETRIES
+
+    db_path = config.settings.database_path
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """INSERT INTO segments
+           (camera, start_ts, end_ts, duration, path, file_size, indexed_at,
+            previews_generated, retry_count, preview_failure_reason)
+           VALUES (?, ?, ?, ?, ?, 1024, ?, 1, ?, 'ffmpeg_nonzero_exit')""",
+        ("reset-cam", 1700400000.0, 1700400010.0, 10.0, "reset-cam/reset.mp4",
+         time.time(), MAX_RETRIES),
+    )
+    conn.commit()
+    seg_id = conn.execute(
+        "SELECT id FROM segments WHERE camera = 'reset-cam'"
+    ).fetchone()[0]
+    conn.close()
+
+    resp = await client.post("/api/admin/reset-preview-failures")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["reset"] >= 1, "Expected at least one segment to be reset"
+
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT previews_generated, retry_count, preview_failure_reason FROM segments WHERE id = ?",
+        (seg_id,),
+    ).fetchone()
+    conn.close()
+    assert row[0] == 0, "previews_generated must be 0 after reset"
+    assert row[1] == 0, "retry_count must be 0 after reset"
+    assert row[2] is None, "preview_failure_reason must be NULL after reset"

--- a/backend/tests/unit/test_preview_generator_v2.py
+++ b/backend/tests/unit/test_preview_generator_v2.py
@@ -366,7 +366,13 @@ class TestRecencyPass:
 
     @pytest.mark.asyncio
     async def test_marks_segment_done_on_failure(self, tmp_path, monkeypatch):
-        """previews_generated is set to 1 even when extract_preview_frame returns None."""
+        """After MAX_RETRIES failures previews_generated is set to 1.
+
+        With the retry logic, a single failure increments retry_count and leaves
+        previews_generated=0. Only on the MAX_RETRIES-th failure is the segment
+        suppressed (previews_generated=1). This test drives the pass MAX_RETRIES
+        times to reach suppression.
+        """
         import app.services.worker as w
         from app import config
 
@@ -378,14 +384,15 @@ class TestRecencyPass:
         conn.execute("""CREATE TABLE segments
             (id INTEGER PRIMARY KEY, camera TEXT, start_ts REAL, end_ts REAL,
              duration REAL, path TEXT, file_size INTEGER, indexed_at REAL,
-             previews_generated INTEGER DEFAULT 0)""")
+             previews_generated INTEGER DEFAULT 0,
+             retry_count INTEGER NOT NULL DEFAULT 0)""")
         conn.execute("""CREATE TABLE previews
             (id INTEGER PRIMARY KEY, camera TEXT, ts REAL, segment_id INTEGER,
              image_path TEXT, width INTEGER, height INTEGER)""")
         import time
         recency_ts = time.time()
         conn.execute(
-            "INSERT INTO segments VALUES (1,'cam',?,?,10.0,'cam/seg.mp4',1024,?,0)",
+            "INSERT INTO segments VALUES (1,'cam',?,?,10.0,'cam/seg.mp4',1024,?,0,0)",
             (recency_ts, recency_ts + 10.0, recency_ts),
         )
         conn.commit()
@@ -395,13 +402,18 @@ class TestRecencyPass:
         monkeypatch.setattr(config.settings, "preview_recency_hours", 168)
         monkeypatch.setattr(w.settings, "preview_recency_hours", 168)
 
-        processed = await w._run_recency_pass(limit=10)
-        assert processed == 1
+        # Drive MAX_RETRIES passes — segment stays in queue until final failure
+        for _ in range(w.MAX_RETRIES):
+            processed = await w._run_recency_pass(limit=10)
+            assert processed == 1
 
         conn = sqlite3.connect(str(db_path))
-        row = conn.execute("SELECT previews_generated FROM segments WHERE id = 1").fetchone()
+        row = conn.execute(
+            "SELECT previews_generated, retry_count FROM segments WHERE id = 1"
+        ).fetchone()
         conn.close()
-        assert row[0] == 1
+        assert row[0] == 1, "previews_generated must be 1 after MAX_RETRIES failures"
+        assert row[1] == w.MAX_RETRIES, f"retry_count must be {w.MAX_RETRIES}"
 
         conn = sqlite3.connect(str(db_path))
         count = conn.execute("SELECT COUNT(*) FROM previews").fetchone()[0]
@@ -422,14 +434,15 @@ class TestRecencyPass:
         conn.execute("""CREATE TABLE segments
             (id INTEGER PRIMARY KEY, camera TEXT, start_ts REAL, end_ts REAL,
              duration REAL, path TEXT, file_size INTEGER, indexed_at REAL,
-             previews_generated INTEGER DEFAULT 0)""")
+             previews_generated INTEGER DEFAULT 0,
+             retry_count INTEGER NOT NULL DEFAULT 0)""")
         conn.execute("""CREATE TABLE previews
             (id INTEGER PRIMARY KEY, camera TEXT, ts REAL, segment_id INTEGER,
              image_path TEXT, width INTEGER, height INTEGER)""")
         import time
         recency_ts = time.time()
         conn.execute(
-            "INSERT INTO segments VALUES (1,'cam',?,?,10.0,'cam/seg.mp4',1024,?,0)",
+            "INSERT INTO segments VALUES (1,'cam',?,?,10.0,'cam/seg.mp4',1024,?,0,0)",
             (recency_ts, recency_ts + 10.0, recency_ts),
         )
         conn.commit()


### PR DESCRIPTION
## Summary

- Adds `retry_count INTEGER NOT NULL DEFAULT 0` column to `segments` (idempotent `ALTER TABLE` migration)
- Worker pass functions (`_run_recency_pass`, `_run_background_pass`, `_process_scheduler_jobs`) now increment `retry_count` on each failed extraction and only set `previews_generated=1` when `retry_count >= MAX_RETRIES` (3)
- Transient failures (VAAPI spike, I/O blip, transient disk error) recover within 3 worker cycles; permanently broken segments are suppressed after 3 attempts instead of immediately
- `POST /api/admin/reset-preview-failures` now also resets `retry_count = 0` so re-queued segments get a fresh retry budget

## Test plan

- [x] New integration test: drives `_run_recency_pass` N times with `extract_preview_frame=None`; asserts `previews_generated` stays `0` until `retry_count == MAX_RETRIES`, then becomes `1`
- [x] New integration test: `POST /api/admin/reset-preview-failures` resets `previews_generated=0`, `retry_count=0`, and `preview_failure_reason=NULL`
- [x] Updated `TestRecencyPass.test_marks_segment_done_on_failure` to match new retry semantics (drives N passes, checks final suppression)
- [x] 158 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)