### PR TITLE
fix(frontend): reset latestCameraTsRef synchronously on camera switch to prevent ceiling overshoot

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -881,6 +881,13 @@ export default function App() {
     setAutoplayRunning(false);
     setSelectedCamera(name);
     const cam = cameras.find(c => c.name === name);
+    // TODO: Vitest test — latestCameraTsRef reset on camera switch
+    // Reset synchronously so the autoplay RAF ceiling uses the new camera's
+    // latest_ts before the useEffect mirror has a chance to propagate.
+    // Without this, there is a one-render window where latestCameraTsRef still
+    // holds the previous camera's value, causing the ceiling to fall back to
+    // nowTs() + 30 and advance past the new camera's newest recording.
+    latestCameraTsRef.current = cam?.latest_ts ?? null;
     setCursorTs(cam?.latest_ts ?? nowTs());
     setPlaybackTarget(null);
     setTimelineData(null);


### PR DESCRIPTION
## Summary

- On camera switch, `latestCameraTsRef.current` was only updated via a `useEffect` watching `latestCameraTs`. For one render cycle after `setSelectedCamera`, the ref still held the previous camera's value.
- During that window the autoplay RAF ceiling fell back to `nowTs() + 30`, which is almost certainly past the new camera's newest recording, advancing the cursor into empty time.
- Fix: reset `latestCameraTsRef.current` synchronously inside `handleCameraChange`, immediately after `cameras.find()` and before any state updates. The `useEffect` mirror is retained for health-poll `latest_ts` refreshes.

## No automated tests

The frontend has no Vitest harness yet. A `// TODO: Vitest test — latestCameraTsRef reset on camera switch` comment is added above the new line. A full React Testing Library test would mock `cameras`, call `handleCameraChange`, and assert `latestCameraTsRef.current` equals the target camera's `latest_ts` before the next render cycle.

## Test plan

- [ ] Switch cameras while autoplay is running — confirm cursor does not advance past the new camera's newest recording
- [ ] Switch cameras with autoplay idle — confirm `cursorTs` lands at new camera's `latest_ts` as before
- [ ] Confirm `useEffect` ref mirror still fires for health-poll updates (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)