### PR TITLE
fix(frontend): handleEnded reads displayTimeRef.current to avoid stale displayTime closure

### DIFF
--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -653,6 +653,7 @@ export default function VideoPlayer({
     }
   }, [playbackTarget, onTimeUpdate, extendHlsWindow]);
 
+  // TODO: Vitest test — handleEnded reads displayTimeRef.current not stale displayTime
   // TODO: test displayTimeRef is current when handleEnded fires after
   // long playback session — stale state version of this bug was fixed
   // in fix(frontend): displayTimeRef for handleEnded stale closure
@@ -690,7 +691,7 @@ export default function VideoPlayer({
         setIsPlaying(false);
       }
     }
-  }, [playbackTarget, onSegmentAdvance, displayTime, extendHlsWindow]);
+  }, [playbackTarget, onSegmentAdvance, displayTimeRef, extendHlsWindow]);
 
   const handleError = useCallback(() => {
     setError('Failed to load video segment');


### PR DESCRIPTION
## Summary

- `handleEnded` listed `displayTime` (React state) in its dep array instead of `displayTimeRef` (the stable ref).
- `displayTime` is updated on every `onTimeUpdate` call (~250ms during playback), so `handleEnded` was recreated constantly and captured the `displayTime` value from the last render cycle — not the live value when the video actually ended.
- The callback body already read `displayTimeRef.current` correctly; only the dep array was wrong.
- Fix: swap `displayTime` → `displayTimeRef` in the dep array. No body changes needed.

## No automated tests

The frontend has no Vitest harness yet. A `// TODO: Vitest test — handleEnded reads displayTimeRef.current not stale displayTime` comment is added above the `useCallback`. A full test would mock `onTimeUpdate` to advance `displayTimeRef`, trigger `handleEnded`, and assert `extendHlsWindow` was called with the current ref value, not a stale state value.

## Test plan

- [ ] Start HLS playback and let a segment end — confirm `extendHlsWindow` is called with the correct current timestamp
- [ ] Confirm `handleEnded` identity is now stable across `onTimeUpdate` cycles (no churn visible in React DevTools)
- [ ] No regression in segment-advance (non-HLS) path

🤖 Generated with [Claude Code](https://claude.com/claude-code)