### PR TITLE
fix(admin): emit __scanning__ SSE event before directory walk to unblock progress UI

### DIFF
--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -315,7 +315,10 @@ async def admin_reindex(since_hours: float = 72.0):
 
             tag = msg["tag"]
 
-            if tag == "__discovered__":
+            if tag == "__scanning__":
+                yield _sse_json("scanning", {"message": "Scanning directories..."})
+
+            elif tag == "__discovered__":
                 total = msg["total"]
                 by_camera = msg["extra"]
                 if total == 0:

--- a/backend/app/services/indexer.py
+++ b/backend/app/services/indexer.py
@@ -382,6 +382,13 @@ def index_segments_since(
 
     valid_dates = {d for d, _h in valid_hours}
 
+    # Signal to the caller that the directory walk is about to start.
+    # For long windows (168h+) the walk can take 10+ seconds; this lets
+    # the frontend show "Scanning directories..." immediately rather than
+    # leaving the progress UI silent until __discovered__ fires.
+    if progress_callback:
+        progress_callback("__scanning__", 0, 0, {})
+
     # Walk only the matching directories
     mp4_files: list[Path] = []
     try:

--- a/backend/tests/unit/test_indexer_since.py
+++ b/backend/tests/unit/test_indexer_since.py
@@ -1,0 +1,99 @@
+"""Unit tests for index_segments_since — targeted reindex path."""
+
+import os
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.services.indexer import index_segments_since
+
+
+def _make_db(db_path: Path) -> None:
+    """Create a minimal segments table so index_segments_since can run."""
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS segments (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            camera TEXT, start_ts REAL, end_ts REAL, duration REAL,
+            path TEXT UNIQUE, file_size INTEGER, indexed_at REAL,
+            previews_generated INTEGER DEFAULT 0
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+class TestIndexSegmentsSinceScanning:
+    """__scanning__ progress callback fires before any os.scandir call."""
+
+    def test_scanning_callback_fires_before_scandir(self, tmp_path):
+        """progress_callback('__scanning__', ...) must be emitted before the
+        first os.scandir call, so the frontend can show a spinner during the
+        directory walk phase."""
+        call_order = []
+
+        original_scandir = os.scandir
+
+        def recording_scandir(path):
+            call_order.append(("scandir", str(path)))
+            return original_scandir(path)
+
+        def progress_callback(tag, done, total, extra):
+            call_order.append(("callback", tag))
+
+        # Build a minimal recordings tree for the current hour so
+        # index_segments_since has a valid directory to walk.
+        now = time.time()
+        from datetime import datetime, timezone
+        dt = datetime.fromtimestamp(now, tz=timezone.utc)
+        seg_dir = tmp_path / dt.strftime("%Y-%m-%d") / dt.strftime("%H") / "cam-a"
+        seg_dir.mkdir(parents=True)
+        (seg_dir / "00.00.mp4").write_bytes(b"fake")
+
+        db_path = tmp_path / "test.db"
+        _make_db(db_path)
+
+        with patch("app.services.indexer.os.scandir", side_effect=recording_scandir), \
+             patch("app.models.database.init_db_sync"):
+            index_segments_since(
+                since_ts=now - 3600,
+                recordings_path=tmp_path,
+                db_path=db_path,
+                progress_callback=progress_callback,
+            )
+
+        # __scanning__ callback must appear before any scandir call
+        scanning_pos = next(
+            (i for i, e in enumerate(call_order) if e == ("callback", "__scanning__")),
+            None,
+        )
+        assert scanning_pos is not None, "__scanning__ callback was never fired"
+
+        first_scandir_pos = next(
+            (i for i, e in enumerate(call_order) if e[0] == "scandir"),
+            None,
+        )
+        assert first_scandir_pos is not None, "os.scandir was never called"
+        assert scanning_pos < first_scandir_pos, (
+            f"__scanning__ fired at position {scanning_pos} but "
+            f"first os.scandir was at position {first_scandir_pos} — "
+            "scanning callback must precede directory I/O"
+        )
+
+    def test_scanning_callback_not_fired_without_progress_callback(self, tmp_path):
+        """When progress_callback=None, no AttributeError should occur."""
+        db_path = tmp_path / "test.db"
+        _make_db(db_path)
+
+        with patch("app.models.database.init_db_sync"):
+            result = index_segments_since(
+                since_ts=time.time() - 3600,
+                recordings_path=tmp_path,
+                db_path=db_path,
+                progress_callback=None,
+            )
+        # Empty tree → empty result, no crash
+        assert result == {}

--- a/frontend/src/components/AdminPanel.jsx
+++ b/frontend/src/components/AdminPanel.jsx
@@ -145,6 +145,7 @@ function ReindexTab() {
   const [customHours, setCustomHours] = useState('');
   const [reindexProgress, setReindexProgress] = useState(null);
   // null | { done: number, total: number, pct: number }
+  const [scanning, setScanning] = useState(false);
   const bottomRef = useRef(null);
 
   useEffect(() => {
@@ -156,6 +157,7 @@ function ReindexTab() {
     setRunning(true);
     setLines([`▶ Reindexing last ${hours}h…`]);
     setReindexProgress(null);
+    setScanning(false);
 
     try {
       const res = await fetch(`${API}/reindex?since_hours=${hours}`, { method: 'POST' });
@@ -180,7 +182,10 @@ function ReindexTab() {
 
           if (event === 'line') {
             setLines(prev => [...prev, data]);
+          } else if (event === 'scanning') {
+            setScanning(true);
           } else if (event === 'discovered') {
+            setScanning(false);
             try {
               const p = JSON.parse(data);
               if (p.total > 0) {
@@ -193,6 +198,7 @@ function ReindexTab() {
               setReindexProgress({ done: p.done, total: p.total, pct: p.pct });
             } catch {}
           } else if (event === 'done') {
+            setScanning(false);
             setReindexProgress(prev => prev ? { ...prev, pct: 100, done: prev.total } : null);
             try {
               const parsed = JSON.parse(data);
@@ -205,6 +211,7 @@ function ReindexTab() {
             }
             setRunning(false);
           } else if (event === 'error') {
+            setScanning(false);
             try {
               const parsed = JSON.parse(data);
               setLines(prev => [...prev, `✗ Error: ${parsed.msg}`]);
@@ -237,6 +244,17 @@ function ReindexTab() {
         bypassing the incremental scanner. Use this when the timeline shows
         gaps despite recordings existing in Frigate.
       </div>
+
+      {/* Scanning indicator — visible between button press and __discovered__ */}
+      {running && scanning && !reindexProgress && (
+        <div style={{
+          marginBottom: 10, fontSize: 11, color: '#4ecdc4',
+          fontFamily: 'monospace', display: 'flex', alignItems: 'center', gap: 6,
+        }}>
+          <span style={{ animation: 'spin 1s linear infinite', display: 'inline-block' }}>⟳</span>
+          Scanning directories…
+        </div>
+      )}
 
       {/* Progress bar — visible after discovery */}
       {reindexProgress && (


### PR DESCRIPTION
## Summary

- For a 168-hour reindex the directory walk takes 10+ seconds. The SSE stream was silent during this phase, leaving the frontend showing only "Running…" with no feedback — indistinguishable from a hung request
- `indexer.py`: emit `progress_callback('__scanning__', 0, 0, {})` immediately after computing `valid_hours`, before any `os.scandir` I/O
- `admin.py` `_generate`: handle the `__scanning__` tag and yield `event: scanning` with `{"message": "Scanning directories..."}`
- `AdminPanel.jsx` `ReindexTab`: add `scanning` state; show a spinning `⟳ Scanning directories…` status line between button press and `__discovered__`; cleared on `discovered` / `done` / `error`

The progress bar itself still only appears after `__discovered__` (existing behaviour preserved).

## Test plan

- [x] `test_scanning_callback_fires_before_scandir` — monkeypatches `os.scandir` to record call order; asserts `__scanning__` callback position < first `scandir` position
- [x] `test_scanning_callback_not_fired_without_progress_callback` — confirms no crash when `progress_callback=None`
- [x] Full suite: 175/175 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)