### PR TITLE
fix(timeline): span-based activity counting for long-running detections

### DIFF
--- a/backend/app/routers/timeline.py
+++ b/backend/app/routers/timeline.py
@@ -126,12 +126,21 @@ def _compute_activity(
         buckets[t] = {}
         t += bucket_sec
 
-    # Count events into buckets
+    # Count events into every bucket they span.
+    # Cap per-event span to avoid O(n*buckets) work for pathologically long events.
+    MAX_SPAN_BUCKETS = 200
+    DEFAULT_SPAN_SEC = 30.0
+
     for evt in events:
-        b = math.floor(evt.start_ts / bucket_sec) * bucket_sec
-        if b in buckets:
-            label = evt.label
-            buckets[b][label] = buckets[b].get(label, 0) + 1
+        effective_end = evt.end_ts if evt.end_ts is not None else evt.start_ts + DEFAULT_SPAN_SEC
+        first_idx = int(evt.start_ts // bucket_sec)
+        last_idx = int(effective_end // bucket_sec)
+        last_idx = min(last_idx, first_idx + MAX_SPAN_BUCKETS - 1)
+        label = evt.label
+        for idx in range(first_idx, last_idx + 1):
+            b = idx * bucket_sec
+            if b in buckets:
+                buckets[b][label] = buckets[b].get(label, 0) + 1
 
     return [
         ActivityBucket(

--- a/backend/tests/unit/test_timeline.py
+++ b/backend/tests/unit/test_timeline.py
@@ -157,3 +157,76 @@ class TestActivityBuckets:
         assert bucket_60.labels.get("person") == 2
         assert bucket_60.labels.get("car") == 1
         assert bucket_60.count == 3
+
+    def test_event_spanning_multiple_buckets_increments_all(self):
+        """An event spanning 3 buckets must increment all 3 bucket counts."""
+        # range ≤ 1h → bucket_sec = 60
+        range_start = 0.0
+        range_end = 3600.0
+        # Event from t=60 to t=200: spans buckets 60, 120, 180
+        evts = [make_evt("e1", start=60.0, end=200.0)]
+        buckets = _compute_activity(evts, range_start, range_end)
+        bucket_60  = next(b for b in buckets if b.bucket_ts == 60.0)
+        bucket_120 = next(b for b in buckets if b.bucket_ts == 120.0)
+        bucket_180 = next(b for b in buckets if b.bucket_ts == 180.0)
+        bucket_240 = next(b for b in buckets if b.bucket_ts == 240.0)
+        assert bucket_60.count == 1
+        assert bucket_120.count == 1
+        assert bucket_180.count == 1
+        assert bucket_240.count == 0  # event ends at 200, floor(200/60)=3 → bucket 180
+
+    def test_event_contained_in_single_bucket(self):
+        """An event entirely within one bucket increments only that bucket."""
+        range_start = 0.0
+        range_end = 3600.0
+        evts = [make_evt("e1", start=65.0, end=90.0)]  # both in bucket 60
+        buckets = _compute_activity(evts, range_start, range_end)
+        bucket_60  = next(b for b in buckets if b.bucket_ts == 60.0)
+        bucket_120 = next(b for b in buckets if b.bucket_ts == 120.0)
+        assert bucket_60.count == 1
+        assert bucket_120.count == 0
+
+    def test_event_with_none_end_ts_uses_fallback(self):
+        """An event with end_ts=None must use start_ts + 30s as the span."""
+        range_start = 0.0
+        range_end = 3600.0
+        # start=65, end=None → effective_end=95; floor(65/60)=1→bucket 60,
+        # floor(95/60)=1→bucket 60.  Both land in the same bucket.
+        evts = [make_evt("e1", start=65.0, end=None)]
+        buckets = _compute_activity(evts, range_start, range_end)
+        bucket_60  = next(b for b in buckets if b.bucket_ts == 60.0)
+        bucket_120 = next(b for b in buckets if b.bucket_ts == 120.0)
+        assert bucket_60.count == 1
+        assert bucket_120.count == 0
+
+        # start=90, end=None → effective_end=120; floor(90/60)=1→bucket 60,
+        # floor(120/60)=2→bucket 120.  Two buckets get incremented.
+        evts2 = [make_evt("e2", start=90.0, end=None)]
+        buckets2 = _compute_activity(evts2, range_start, range_end)
+        b60  = next(b for b in buckets2 if b.bucket_ts == 60.0)
+        b120 = next(b for b in buckets2 if b.bucket_ts == 120.0)
+        assert b60.count == 1
+        assert b120.count == 1
+
+    def test_pathological_event_is_capped(self):
+        """A 24-hour event must not blow up — capped at MAX_SPAN_BUCKETS=200."""
+        # Use >24h range → bucket_sec=1800
+        range_start = 0.0
+        range_end = 90_000.0  # 25 hours
+        # Event spanning the entire range (86400s / 1800s per bucket = 48 buckets < 200 cap)
+        evts = [make_evt("e1", start=0.0, end=86_400.0)]
+        buckets = _compute_activity(evts, range_start, range_end)
+        # Expect exactly 48 incremented buckets (0, 1800, ..., 46*1800=82800)
+        # floor(86400/1800)=48, so buckets 0..48 → 49 buckets
+        incremented = [b for b in buckets if b.count > 0]
+        assert len(incremented) == 49  # buckets 0 through 48*1800
+
+        # Now test the cap: event so long it would exceed 200 buckets
+        # bucket_sec=1800, 200 buckets = 360000s
+        # Event 0..720000 → would be 400 buckets without cap
+        evts_huge = [make_evt("e2", start=0.0, end=720_000.0)]
+        # range must contain at least 200 buckets
+        range_end_huge = 720_000.0 + 1800.0
+        buckets_huge = _compute_activity(evts_huge, 0.0, range_end_huge)
+        incremented_huge = [b for b in buckets_huge if b.count > 0]
+        assert len(incremented_huge) == 200  # capped


### PR DESCRIPTION
## Summary

- `_compute_activity` previously assigned each event only to the bucket containing `start_ts`, so a detection spanning multiple buckets only appeared in the first one
- This diverged from the `/api/timeline/density` endpoint (which already uses overlap-aware counting), producing inconsistent heatmap data
- Fix: iterate from `floor(start_ts / bucket_sec)` through `floor(end_ts / bucket_sec)` inclusive; `end_ts=None` falls back to `start_ts + 30s`; per-event span is capped at 200 buckets to prevent O(n×buckets) blowup on pathological events

## Test plan

- [x] `test_event_spanning_multiple_buckets_increments_all` — event at 60–200s increments buckets 60, 120, 180 but not 240
- [x] `test_event_contained_in_single_bucket` — event at 65–90s only increments bucket 60
- [x] `test_event_with_none_end_ts_uses_fallback` — `end_ts=None` uses `start_ts + 30s`; correct single-bucket and two-bucket cases verified
- [x] `test_pathological_event_is_capped` — 24h event counts correctly (49 buckets); 400-bucket event is capped at 200
- [x] All 179 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)