### PR TITLE
fix(timeline): cap scroll velocity at 10% of range and 3600s ceiling to prevent wide-zoom overshoot

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -819,8 +819,9 @@ export default function VerticalTimeline({
       // Impulse BEFORE clamp: first frame reflects raw intent.
       onPan(scrollVelocityRef.current);
 
-      // Raised cap: fast flicks can really travel at wide zoom.
-      const maxV = (endTs - startTs) * 0.25;
+      // Cap: 10% of visible range, max 3600s — prevents 6h overshoot on
+      // trackpad flick at 24h zoom. See CLAUDE.md scroll interaction model.
+      const maxV = Math.min((endTs - startTs) * 0.10, 3600);
       scrollVelocityRef.current = Math.max(
         -maxV,
         Math.min(maxV, scrollVelocityRef.current)


### PR DESCRIPTION
## Summary

- At 24h zoom, the old `0.25` velocity cap allowed ~21,600 s/frame — a fast trackpad flick could jump 6+ hours before `DAMPING=0.88` bled off momentum
- New formula: `Math.min((endTs - startTs) * 0.10, 3600)` — caps single-frame overshoot at 1 hour regardless of zoom level
- At tight zoom (5-min range): `min(30s, 3600s) = 30s` — identical to prior intent
- `DAMPING` (0.88), `K` (0.22), delta normalization (40 max), and all other scroll physics constants from CLAUDE.md are unchanged

## Test plan

No automated frontend test harness exists for scroll physics. Manual verification:
- [ ] Trackpad flick at 24h zoom: confirm scroll decelerates within ~1 hour, not 6+
- [ ] Trackpad flick at 5-min zoom: confirm tight control still feels precise
- [ ] Mouse wheel at intermediate zoom levels: confirm momentum/glide behavior preserved

A comment above the `maxV` line documents the rationale inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)