### PR TITLE
fix(preview_generator): lazy VAAPI probe on first use instead of at import time

### DIFF
--- a/backend/app/services/preview_generator.py
+++ b/backend/app/services/preview_generator.py
@@ -79,12 +79,31 @@ def _vaapi_device() -> str | None:
         return None
 
 
-_VAAPI_DEVICE: str | None = _vaapi_device()
+# Lazy VAAPI probe — not evaluated at import time to avoid stalling startup.
+# 'unchecked' is the sentinel meaning the probe has not yet run.
+_VAAPI_DEVICE: str | None = "unchecked"  # type: ignore[assignment]
+_VAAPI_LOCK = threading.Lock()
 
-if _VAAPI_DEVICE:
-    log.info("VAAPI hardware decode enabled (%s)", _VAAPI_DEVICE)
-else:
-    log.info("VAAPI not available, using software decode")
+
+def _get_vaapi_device() -> str | None:
+    """Return the VAAPI device path, probing on first call (lazy init).
+
+    Uses double-checked locking so the probe runs exactly once even when
+    multiple worker threads call this simultaneously on startup.
+    """
+    global _VAAPI_DEVICE
+    if _VAAPI_DEVICE != "unchecked":
+        return _VAAPI_DEVICE  # type: ignore[return-value]
+    with _VAAPI_LOCK:
+        if _VAAPI_DEVICE != "unchecked":  # double-checked locking
+            return _VAAPI_DEVICE  # type: ignore[return-value]
+        _VAAPI_DEVICE = _vaapi_device()
+        if _VAAPI_DEVICE:
+            log.info("VAAPI hardware decode enabled (%s)", _VAAPI_DEVICE)
+        else:
+            log.info("VAAPI not available, using software decode")
+        return _VAAPI_DEVICE  # type: ignore[return-value]
+
 
 # Serialize VAAPI access — a single iGPU does not parallelize across
 # concurrent ffmpeg processes.  Software-decode workers are not gated.
@@ -167,15 +186,16 @@ def extract_preview_frame(
         }
 
     # Step 3 — Run exactly ONE ffmpeg subprocess
+    vaapi_dev = _get_vaapi_device()
     hw_flags: list[str] = []
-    if _VAAPI_DEVICE:
+    if vaapi_dev:
         hw_flags = [
             "-hwaccel", "vaapi",
-            "-hwaccel_device", _VAAPI_DEVICE,
+            "-hwaccel_device", vaapi_dev,
             "-hwaccel_output_format", "vaapi",
         ]
 
-    if _VAAPI_DEVICE:
+    if vaapi_dev:
         vf = f"hwdownload,format=nv12,scale={width}:-1"
     else:
         vf = f"scale={width}:-1"
@@ -196,7 +216,7 @@ def extract_preview_frame(
     ]
 
     try:
-        if _VAAPI_DEVICE:
+        if vaapi_dev:
             with _vaapi_semaphore:
                 result = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
         else:

--- a/backend/tests/unit/test_preview_generator_v2.py
+++ b/backend/tests/unit/test_preview_generator_v2.py
@@ -358,6 +358,110 @@ class TestVaapiSemaphore:
         assert pg._VAAPI_MAX_CONCURRENT == 1
 
 
+class TestLazyVaapiProbe:
+
+    def test_get_vaapi_device_returns_probe_result(self, monkeypatch):
+        """_get_vaapi_device() calls _vaapi_device() and returns its result."""
+        import app.services.preview_generator as pg
+
+        monkeypatch.setattr(pg, "_VAAPI_DEVICE", "unchecked")
+        monkeypatch.setattr(pg, "_vaapi_device", lambda: "/dev/dri/renderD128")
+
+        result = pg._get_vaapi_device()
+        assert result == "/dev/dri/renderD128"
+
+    def test_get_vaapi_device_cached_after_first_call(self, monkeypatch):
+        """_vaapi_device() is called exactly once; subsequent calls use the cached value."""
+        import app.services.preview_generator as pg
+
+        call_count = {"n": 0}
+
+        def counting_probe():
+            call_count["n"] += 1
+            return "/dev/dri/renderD128"
+
+        monkeypatch.setattr(pg, "_VAAPI_DEVICE", "unchecked")
+        monkeypatch.setattr(pg, "_vaapi_device", counting_probe)
+
+        pg._get_vaapi_device()
+        pg._get_vaapi_device()
+        pg._get_vaapi_device()
+
+        assert call_count["n"] == 1, "_vaapi_device must be called exactly once"
+
+    def test_vaapi_probe_not_called_at_import_time(self):
+        """Reloading the module must not invoke _vaapi_device().
+
+        Verified by patching shutil.which (the first call inside _vaapi_device)
+        to raise — if any module-level code calls the probe, reload raises.
+        """
+        import importlib
+        import shutil
+        import app.services.preview_generator as pg
+
+        original_which = shutil.which
+        called = {"probe": False}
+
+        def raising_which(name):
+            if name == "ffmpeg":
+                called["probe"] = True
+                raise AssertionError("_vaapi_device was called at import/reload time")
+            return original_which(name)
+
+        shutil.which = raising_which
+        try:
+            importlib.reload(pg)
+            assert not called["probe"], "_vaapi_device must not run at module import"
+            assert pg._VAAPI_DEVICE == "unchecked", "sentinel must be set after reload"
+        finally:
+            shutil.which = original_which
+            # Restore module to a clean post-reload state
+            importlib.reload(pg)
+
+    def test_get_vaapi_device_called_once_under_concurrency(self, monkeypatch):
+        """Two threads calling _get_vaapi_device() simultaneously must trigger exactly one probe.
+
+        The barrier belongs in the caller (not the probe) so both threads race
+        to the first unchecked check simultaneously; only one wins the lock and
+        calls _vaapi_device(); the second sees the updated value and short-circuits.
+        """
+        import time
+        import app.services.preview_generator as pg
+
+        call_count = {"n": 0}
+        start_barrier = threading.Barrier(2)
+
+        def slow_probe():
+            call_count["n"] += 1
+            time.sleep(0.05)  # hold lock briefly so second thread is definitely waiting
+            return "/dev/dri/renderD128"
+
+        monkeypatch.setattr(pg, "_VAAPI_DEVICE", "unchecked")
+        monkeypatch.setattr(pg, "_vaapi_device", slow_probe)
+        # Reset the lock so double-checked locking starts from a clean state
+        monkeypatch.setattr(pg, "_VAAPI_LOCK", threading.Lock())
+
+        results = []
+
+        def caller():
+            start_barrier.wait()  # both threads enter simultaneously
+            results.append(pg._get_vaapi_device())
+
+        t1 = threading.Thread(target=caller)
+        t2 = threading.Thread(target=caller)
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert call_count["n"] == 1, (
+            f"_vaapi_device must be called exactly once under concurrency, got {call_count['n']}"
+        )
+        assert all(r == "/dev/dri/renderD128" for r in results), (
+            "Both callers must receive the correct device path"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Recency pass tests (via worker helpers)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- \`_vaapi_device()\` previously ran a blocking ffmpeg null-source test at module import time, adding 1–3 s to FastAPI cold start; on systems with a broken VAAPI driver it could hang for the full 5-second timeout
- Added \`_get_vaapi_device()\` with double-checked locking — probe runs exactly once on first call from a worker thread, never at import time
- \`_VAAPI_DEVICE\` is initialized to the sentinel \`\"unchecked\"\`; callers read it via \`_get_vaapi_device()\`, not directly
- All three reads of \`_VAAPI_DEVICE\` in \`extract_preview_frame\` replaced with a single \`vaapi_dev = _get_vaapi_device()\` capture before the ffmpeg command is built

## Test plan

- [x] \`test_get_vaapi_device_returns_probe_result\` — returns value from \`_vaapi_device()\` on first call
- [x] \`test_get_vaapi_device_cached_after_first_call\` — \`_vaapi_device()\` called exactly once across three sequential calls
- [x] \`test_vaapi_probe_not_called_at_import_time\` — patches \`shutil.which\` to raise, reloads module, asserts no exception and \`_VAAPI_DEVICE == "unchecked"\`
- [x] \`test_get_vaapi_device_called_once_under_concurrency\` — \`threading.Barrier\` forces two threads to race simultaneously; probe called exactly once, both threads receive correct device path
- [x] All 183 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)