### PR TITLE
fix(frontend): reset nearEventCacheRef synchronously on camera switch

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -870,6 +870,9 @@ export default function App() {
   // Falls back to nowTs() — never sets cursorTs to null which would NaN-cascade
   // into rangeStart/rangeEnd, API fetches, and the autoplay RAF loop.
   const handleCameraChange = useCallback((name) => {
+    // Reset synchronously so RAF tick never magnetizes to a previous
+    // camera's events during the state-update transition window.
+    nearEventCacheRef.current = { sorted: [], event: null };
     preloadRequestRef.current++; // cancel in-flight idle preload for old camera
     idlePreloadStartedRef.current = false;
     if (import.meta.env.DEV) {


### PR DESCRIPTION
## Summary

- On camera switch, `nearEventCacheRef` is rebuilt by a `useEffect` watching `filteredEvents`, but the effect fires asynchronously after the render cycle.
- During the transition window, the RAF autoplay tick could read sorted event timestamps from the previous camera and apply magnetization toward a stale (now non-existent) event timestamp.
- Fix: reset `nearEventCacheRef.current = { sorted: [], event: null }` synchronously at the top of `handleCameraChange`, before any state updates propagate — mirroring the existing synchronous reset pattern used for `latestCameraTsRef`.

## No tests

No frontend test harness covers React state closure timing. The fix follows the same synchronous-reset pattern already established for `latestCameraTsRef` in the same function. TODO: add a Vitest test when the frontend test infrastructure is expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)