### PR TITLE
feat(frontend): add React ErrorBoundary to Timeline, VideoPlayer, and app root

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import CameraSelector from './components/CameraSelector.jsx';
 import VerticalTimeline from './components/VerticalTimeline.jsx';
 import VideoPlayer from './components/VideoPlayer.jsx';
 import AdminPanel from './components/AdminPanel.jsx';
+import { ErrorBoundary } from './components/ErrorBoundary.jsx';
 import {
   fetchCameras,
   fetchDensity,
@@ -1236,26 +1237,28 @@ export default function App() {
           {/* Left/top: video viewer column */}
           <div style={{ ...styles.viewerCol, flex: isMobile ? 'none' : 1 }}>
             <div style={{ flex: 1, minHeight: 0 }}>
-              <VideoPlayer
-                playbackTarget={playbackTarget}
-                camera={selectedCamera}
-                onTimeUpdate={handlePlaybackTimeUpdate}
-                onSegmentAdvance={handleSegmentAdvance}
-                scrubPreviewUrl={reticlePreviewUrl}
-                isMobile={isMobile}
-                eventSnapshot={activeEventSnapshot}
-                onSeek={handleSeek}
-                onPlaybackStart={handlePlaybackStart}
-                preloadTargetTs={preloadTargetTs}
-                preloadTarget={preloadTarget}
-                autoplayActive={autoplayRunning}
-                onPlaybackStateChange={(playing) => { videoPlayingRef.current = playing; }}
-                debugOverrides={import.meta.env.DEV ? debugOverrides : null}
-                onScrubPreviewStatus={import.meta.env.DEV ? setDebugScrubPreviewStatus : null}
-                onDebugIsPlaying={import.meta.env.DEV ? setDebugIsPlaying : null}
-                onDebugDisplayedUrl={import.meta.env.DEV ? setDebugDisplayedUrl : null}
-                onDebugEvent={import.meta.env.DEV ? onDebugEventStable : null}
-              />
+              <ErrorBoundary label="Video Player">
+                <VideoPlayer
+                  playbackTarget={playbackTarget}
+                  camera={selectedCamera}
+                  onTimeUpdate={handlePlaybackTimeUpdate}
+                  onSegmentAdvance={handleSegmentAdvance}
+                  scrubPreviewUrl={reticlePreviewUrl}
+                  isMobile={isMobile}
+                  eventSnapshot={activeEventSnapshot}
+                  onSeek={handleSeek}
+                  onPlaybackStart={handlePlaybackStart}
+                  preloadTargetTs={preloadTargetTs}
+                  preloadTarget={preloadTarget}
+                  autoplayActive={autoplayRunning}
+                  onPlaybackStateChange={(playing) => { videoPlayingRef.current = playing; }}
+                  debugOverrides={import.meta.env.DEV ? debugOverrides : null}
+                  onScrubPreviewStatus={import.meta.env.DEV ? setDebugScrubPreviewStatus : null}
+                  onDebugIsPlaying={import.meta.env.DEV ? setDebugIsPlaying : null}
+                  onDebugDisplayedUrl={import.meta.env.DEV ? setDebugDisplayedUrl : null}
+                  onDebugEvent={import.meta.env.DEV ? onDebugEventStable : null}
+                />
+              </ErrorBoundary>
             </div>
 
             {/* Footer: timestamp + coverage stats */}
@@ -1305,26 +1308,28 @@ export default function App() {
 
             {/* VerticalTimeline */}
             <div style={{ flex: 1, minHeight: 0 }}>
-              <VerticalTimeline
-                startTs={rangeStart}
-                endTs={rangeEnd}
-                gaps={timelineData?.gaps || []}
-                events={filteredEvents}
-                densityData={densityData}
-                activeLabels={activeLabels}
-                cursorTs={cursorTs}
-                onSeek={handleSeek}
-                onPan={handlePan}
-                onZoomChange={handleZoomChange}
-                autoplayState={autoplayState}
-                isMobile={isMobile}
-                timeFormat={timeFormat}
-                onPreviewRequest={(ts) => {
-                  const halfWindow = 5 * 60;
-                  requestPreviews(selectedCamera, ts - halfWindow, ts + halfWindow).catch(() => {});
-                }}
-                onPreloadHint={handlePreloadHint}
-              />
+              <ErrorBoundary label="Timeline">
+                <VerticalTimeline
+                  startTs={rangeStart}
+                  endTs={rangeEnd}
+                  gaps={timelineData?.gaps || []}
+                  events={filteredEvents}
+                  densityData={densityData}
+                  activeLabels={activeLabels}
+                  cursorTs={cursorTs}
+                  onSeek={handleSeek}
+                  onPan={handlePan}
+                  onZoomChange={handleZoomChange}
+                  autoplayState={autoplayState}
+                  isMobile={isMobile}
+                  timeFormat={timeFormat}
+                  onPreviewRequest={(ts) => {
+                    const halfWindow = 5 * 60;
+                    requestPreviews(selectedCamera, ts - halfWindow, ts + halfWindow).catch(() => {});
+                  }}
+                  onPreloadHint={handlePreloadHint}
+                />
+              </ErrorBoundary>
             </div>
 
             {/* Bottom range label */}

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+// TODO: Vitest test — ErrorBoundary catches thrown child error and
+// renders fallback without unmounting sibling panels.
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('[ErrorBoundary]', error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback ?? (
+        <div style={{ padding: 16, color: '#ff6b6b', background: '#1a1a2e',
+                      borderRadius: 8, fontFamily: 'monospace', fontSize: 12 }}>
+          <strong>{this.props.label ?? 'Component'} error</strong>
+          <pre style={{ marginTop: 8, whiteSpace: 'pre-wrap' }}>
+            {this.state.error?.message}
+          </pre>
+          <button onClick={() => this.setState({ hasError: false, error: null })}
+                  style={{ marginTop: 8, padding: '4px 12px', cursor: 'pointer' }}>
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,4 +1,9 @@
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import { ErrorBoundary } from './components/ErrorBoundary.jsx';
 
-createRoot(document.getElementById('root')).render(<App />);
+createRoot(document.getElementById('root')).render(
+  <ErrorBoundary label="App">
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary

- Creates `frontend/src/components/ErrorBoundary.jsx` as a React class component (error boundaries require class components)
- Wraps `<VideoPlayer>` and `<VerticalTimeline>` in `App.jsx` with independent `<ErrorBoundary>` instances
- Wraps `<App>` in `main.jsx` with a root-level boundary as a last-resort catch

## Motivation

A runtime exception in `VerticalTimeline.jsx` (e.g. NaN from a bad timestamp), `VideoPlayer.jsx` (unexpected HLS.js error path), or `App.jsx` (null-deref at startup) previously unmounted the entire application and displayed a blank white screen. For an NVR review interface used during security incidents this is a meaningful reliability regression.

With independent boundaries, a crash in the timeline panel leaves the video player functional and vice versa. A Retry button resets `hasError` so the user can recover without a full page reload.

## Test plan

- No frontend test harness exists for React component tests
- `// TODO: Vitest test — ErrorBoundary catches thrown child error and renders fallback without unmounting sibling panels.` added to `ErrorBoundary.jsx`
- Manual verification: throw in a child component, confirm boundary renders error message + Retry button; confirm sibling panels remain mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)