### PR TITLE
fix(worker): use _preview_executor in _process_scheduler_jobs, not default executor

### DIFF
--- a/backend/app/services/worker.py
+++ b/backend/app/services/worker.py
@@ -308,7 +308,7 @@ async def _process_scheduler_jobs(jobs: list) -> int:
 
                 # ffmpeg runs in executor — do not block the event loop
                 frame = await loop.run_in_executor(
-                    None,
+                    _preview_executor,
                     lambda s=segment, j=job: extract_preview_frame(
                         camera=s["camera"],
                         ts=j.bucket_ts,

--- a/backend/tests/unit/test_worker_executor.py
+++ b/backend/tests/unit/test_worker_executor.py
@@ -39,6 +39,110 @@ def test_executor_respects_preview_workers(monkeypatch):
         executor.shutdown(wait=False)
 
 
+def test_process_scheduler_jobs_uses_preview_executor(monkeypatch):
+    """_process_scheduler_jobs must pass _preview_executor, not None, to run_in_executor.
+
+    Regression guard for the bug where _process_scheduler_jobs used None while
+    the other three tiers (_process_demand_queue, _run_recency_pass,
+    _run_background_pass) correctly used _preview_executor.  Using None bypasses
+    the preview_workers ceiling and VAAPI serialization intent.
+    """
+    import asyncio
+    from concurrent.futures import ThreadPoolExecutor
+    import app.services.worker as worker_mod
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    captured_executors: list = []
+
+    async def fake_run_in_executor(exc, fn, *args):
+        captured_executors.append(exc)
+        return None  # simulate no frame produced
+
+    try:
+        worker_mod.set_preview_executor(executor)
+
+        # Build a minimal fake job that matches what PreviewScheduler produces.
+        class FakeJob:
+            camera = "cam_a"
+            bucket_ts = 1700001000.0
+
+        # Patch get_db to return an async context manager with a stub db
+        class FakeDb:
+            async def execute_fetchall(self, *a, **kw):
+                return []  # no matching segments → job skipped cleanly
+
+            async def execute(self, *a, **kw):
+                pass
+
+            async def commit(self):
+                pass
+
+        class FakeDbCtx:
+            async def __aenter__(self):
+                return FakeDb()
+
+            async def __aexit__(self, *a):
+                pass
+
+        monkeypatch.setattr(worker_mod, "get_db", lambda: FakeDbCtx())
+
+        # Patch the event loop's run_in_executor to capture the executor arg.
+        loop = asyncio.new_event_loop()
+        monkeypatch.setattr(loop, "run_in_executor", fake_run_in_executor)
+
+        try:
+            loop.run_until_complete(worker_mod._process_scheduler_jobs([FakeJob()]))
+        finally:
+            loop.close()
+
+        # The DB query returned no rows, so run_in_executor was never called.
+        # Inject a row so the executor path is reached.
+        # Re-run with a segment that matches the job's bucket_ts.
+        class FakeDbWithRow:
+            async def execute_fetchall(self, *a, **kw):
+                return [
+                    {
+                        "id": 1,
+                        "camera": "cam_a",
+                        "start_ts": 1700000990.0,
+                        "end_ts": 1700001010.0,
+                        "duration": 20.0,
+                        "path": "cam_a/2023-11-14/some.mp4",
+                    }
+                ]
+
+            async def execute(self, *a, **kw):
+                pass
+
+            async def commit(self):
+                pass
+
+        class FakeDbCtxWithRow:
+            async def __aenter__(self):
+                return FakeDbWithRow()
+
+            async def __aexit__(self, *a):
+                pass
+
+        monkeypatch.setattr(worker_mod, "get_db", lambda: FakeDbCtxWithRow())
+
+        captured_executors.clear()
+        loop2 = asyncio.new_event_loop()
+        monkeypatch.setattr(loop2, "run_in_executor", fake_run_in_executor)
+        try:
+            loop2.run_until_complete(worker_mod._process_scheduler_jobs([FakeJob()]))
+        finally:
+            loop2.close()
+
+        assert len(captured_executors) == 1, "run_in_executor should have been called once"
+        assert captured_executors[0] is executor, (
+            "_process_scheduler_jobs must pass _preview_executor, not None"
+        )
+    finally:
+        worker_mod._preview_executor = None
+        executor.shutdown(wait=False)
+
+
 def test_executor_thread_name_prefix():
     """Executor threads must carry the preview-worker prefix for log tracing."""
     executor = ThreadPoolExecutor(


### PR DESCRIPTION
## Summary

- Replaces `None` with `_preview_executor` in the single `run_in_executor` call inside `_process_scheduler_jobs`
- Adds `test_process_scheduler_jobs_uses_preview_executor` to `test_worker_executor.py`

## Problem

`_process_scheduler_jobs` was passing `None` to `run_in_executor` while the other three tiers (`_process_demand_queue`, `_run_recency_pass`, `_run_background_pass`) correctly passed `_preview_executor`.

Using `None` routes work to Python's default `ThreadPoolExecutor` which sizes to `min(32, cpu_count+4)` threads and silently ignores the `preview_workers` config ceiling. This is the worst place for the bug to exist: scheduler jobs are viewport-driven, highest-priority work the user is actively waiting on, and the most likely to saturate the iGPU decoder if unbounded.

## Fix

```python
# Before
frame = await loop.run_in_executor(
    None,
    lambda s=segment, j=job: extract_preview_frame(...)
)

# After
frame = await loop.run_in_executor(
    _preview_executor,
    lambda s=segment, j=job: extract_preview_frame(...)
)
```

## Test

`test_process_scheduler_jobs_uses_preview_executor` monkeypatches `get_db` to return a fake segment matching the job's `bucket_ts`, sets `_preview_executor` to a real `ThreadPoolExecutor`, patches `loop.run_in_executor` to capture the executor argument, runs `_process_scheduler_jobs`, and asserts the captured executor is `_preview_executor`, not `None`.

## Test run

```
188 passed in 7.13s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)