### PR TITLE
fix(timeline): remove autoplayState from drawCanvas deps to eliminate spurious 60fps redraws

### DIFF
--- a/frontend/src/components/VerticalTimeline.jsx
+++ b/frontend/src/components/VerticalTimeline.jsx
@@ -670,7 +670,9 @@ export default function VerticalTimeline({
       ctx.fill();
 
     }
-  }, [dims, startTs, endTs, gaps, events, densityData, activeLabels, autoplayState, tsToY, timeFormat,
+  // autoplayState intentionally omitted — not read inside drawCanvas.
+  // Adding it causes full redraws on every autoplay state transition (~60fps).
+  }, [dims, startTs, endTs, gaps, events, densityData, activeLabels, tsToY, timeFormat,
       fontFamily, tickFontSize, tickFontWeight, tickFontStyle, tickColor,
       labelFontSize, labelFontWeight, labelFontStyle, secondsAccentColor,
       backgroundColor, tickLabelXPct, paddingLeft, paddingRight, tickLabelLeft, showDensity]);


### PR DESCRIPTION
## Summary

Removes `autoplayState` from the `drawCanvas` `useCallback` dependency array in `VerticalTimeline.jsx`. It was the only dep change; no logic inside `drawCanvas` was modified.

## Problem

`drawCanvas` listed `autoplayState` in its deps but **never reads it** in its 200+ line body (confirmed by grep — the only two occurrences in the file are the prop destructure default and the now-removed dep entry).

During autoplay, `autoplayState` cycles through `'idle'` → `'advancing'` → `'approaching_event'` on state transitions. Each transition invalidated `drawCanvas`, triggering a full canvas redraw that includes:

- The `O(h × density_buckets)` density gradient pass (Float32Array allocation, box blur, per-pixel colour mapping)
- All tick/label rendering
- All event marker rendering

On a 600 px canvas with 720 density buckets this is **~432,000 pixel-density calculations per spurious transition**, on top of the per-frame `drawReticleOnly` calls that correctly handle cursor movement.

## Fix

```js
// Before
}, [dims, startTs, endTs, gaps, events, densityData, activeLabels, autoplayState, tsToY, timeFormat, ...]);

// After — autoplayState intentionally omitted — not read inside drawCanvas.
// Adding it causes full redraws on every autoplay state transition (~60fps).
}, [dims, startTs, endTs, gaps, events, densityData, activeLabels, tsToY, timeFormat, ...]);
```

`drawReticleOnly`'s dep array (`[dims, startTs, endTs, paddingLeft, paddingRight]`) correctly omits `autoplayState` already — no change needed there.

## Tests

No frontend canvas test harness. Comment added above the dep array documents the intent so the dep is not accidentally re-added without a corresponding rendering change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)