### PR TITLE
feat(frontend): wire snapToCoverage into handleSeek, handlePan, and RAF autoplay tick

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "hls.js": "^1.5.0",
@@ -15,9 +18,15 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/user-event": "^14.0.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
-    "vite": "^6.0.5"
+    "@vitest/ui": "^1.0.0",
+    "jsdom": "^24.0.0",
+    "vite": "^6.0.5",
+    "vitest": "^1.0.0"
   }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -319,6 +319,10 @@ export default function App() {
   // Ref mirror so the RAF tick can read the current ceiling without stale closure.
   const latestCameraTsRef = useRef(null);
   useEffect(() => { latestCameraTsRef.current = latestCameraTs; }, [latestCameraTs]);
+  // segmentsRef: mirrors timelineData?.segments so functional updaters (handlePan,
+  // RAF tick) can call snapToCoverage without capturing stale state in a closure.
+  const segmentsRef = useRef([]);
+  useEffect(() => { segmentsRef.current = timelineData?.segments ?? []; }, [timelineData]);
   // preloadRequestRef: incremented on interaction to cancel in-flight preload fetches.
   // idlePreloadStartedRef: prevents re-firing preload within the same idle window.
   // TODO: test preload cancel — preloadRequestRef increment on interaction discards
@@ -415,7 +419,8 @@ export default function App() {
           // +30s slack: /api/cameras polls every 30s, so latest_ts may lag wall-clock
           // by up to 30s for in-progress recordings.
           const ceiling = (latestCameraTsRef.current ?? nowTs()) + 30;
-          return Math.min(prev + advanceSec, ceiling);
+          const next = Math.min(prev + advanceSec, ceiling);
+          return snapToCoverage(next, segmentsRef.current);
         });
       } else {
         if (autoplayActiveRef.current) {
@@ -630,7 +635,10 @@ export default function App() {
     // +30s slack: /api/cameras polls every 30s, so latest_ts may lag wall-clock
     // by up to 30s for in-progress recordings.
     const ceiling = (latestCameraTsRef.current ?? nowTs()) + 30;
-    setCursorTs(prev => Math.min(prev + deltaSec, ceiling));
+    setCursorTs(prev => {
+      const next = Math.min(prev + deltaSec, ceiling);
+      return snapToCoverage(next, segmentsRef.current);
+    });
   }, []);
 
   // ─── Zoom: change visible window width, keeping cursorTs fixed ───
@@ -656,7 +664,7 @@ export default function App() {
     idlePreloadStartedRef.current = false; // allow fresh preload after 400ms
     setPreloadTarget(null);
     setAutoplayRunning(false);
-    setCursorTs(ts);
+    setCursorTs(snapToCoverage(ts, segmentsRef.current));
     setActiveEventSnapshot(null);
   }, []);
 

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,6 +1,7 @@
 import { expect } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 
+// Extend Vitest's expect with jest-dom DOM matchers (toBeInTheDocument, etc.)
 expect.extend(matchers);
 
 // Mock matchMedia — jsdom does not implement this; useIsMobile() depends on it.

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,0 +1,26 @@
+import { expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);
+
+// Mock matchMedia — jsdom does not implement this; useIsMobile() depends on it.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});
+
+// Stub requestAnimationFrame so App's RAF autoplay loop does not fire during
+// tests. jsdom's implementation can call callbacks unexpectedly, causing
+// cursorTs to advance between assertion points.
+let _rafId = 0;
+global.requestAnimationFrame = () => ++_rafId;
+global.cancelAnimationFrame = () => {};

--- a/frontend/src/test/snapToCoverage.test.js
+++ b/frontend/src/test/snapToCoverage.test.js
@@ -1,0 +1,116 @@
+/**
+ * Tests for snapToCoverage() — the binary-search helper that snaps a candidate
+ * timestamp to the nearest covered position in the segments array.
+ *
+ * snapToCoverage is a module-scope function in App.jsx and is not exported, so
+ * we test the logic directly here by duplicating the pure function.  Any change
+ * to the implementation in App.jsx must be reflected here.
+ *
+ * Invariants under test:
+ *   - ts inside a segment → returned unchanged
+ *   - ts in a gap → snaps to nearer segment edge (both directions)
+ *   - ts before all segments → snaps to first segment's start_ts
+ *   - ts after all segments → snaps to last segment's end_ts
+ *   - empty segments array → ts returned unchanged
+ *   - null/undefined segments → ts returned unchanged
+ */
+import { describe, it, expect } from 'vitest';
+
+// Mirror of App.jsx snapToCoverage — kept in sync by convention.
+function snapToCoverage(ts, segments) {
+  if (!segments?.length) return ts;
+  let lo = 0, hi = segments.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    const seg = segments[mid];
+    if (ts < seg.start_ts) hi = mid - 1;
+    else if (ts > seg.end_ts) lo = mid + 1;
+    else return ts; // inside a segment — no snap needed
+  }
+  // In a gap: lo = index of first segment after ts
+  const prev = lo > 0 ? segments[lo - 1] : null;
+  const next = lo < segments.length ? segments[lo] : null;
+  if (!prev) return next.start_ts;
+  if (!next) return prev.end_ts;
+  return (ts - prev.end_ts) <= (next.start_ts - ts) ? prev.end_ts : next.start_ts;
+}
+
+// Minimal segment factory.
+function seg(start_ts, end_ts) {
+  return { start_ts, end_ts };
+}
+
+const SEGMENTS = [
+  seg(100, 200),
+  seg(300, 400),
+  seg(600, 700),
+];
+
+describe('snapToCoverage — inside segment', () => {
+  it('returns ts unchanged when ts is exactly at start_ts', () => {
+    expect(snapToCoverage(100, SEGMENTS)).toBe(100);
+  });
+
+  it('returns ts unchanged when ts is exactly at end_ts', () => {
+    expect(snapToCoverage(200, SEGMENTS)).toBe(200);
+  });
+
+  it('returns ts unchanged when ts is inside a segment', () => {
+    expect(snapToCoverage(150, SEGMENTS)).toBe(150);
+    expect(snapToCoverage(350, SEGMENTS)).toBe(350);
+    expect(snapToCoverage(650, SEGMENTS)).toBe(650);
+  });
+});
+
+describe('snapToCoverage — gap snapping', () => {
+  it('snaps to prev.end_ts when closer to the previous segment', () => {
+    // Gap between 200 and 300. ts=210 is 10 from prev.end and 90 from next.start
+    expect(snapToCoverage(210, SEGMENTS)).toBe(200);
+  });
+
+  it('snaps to next.start_ts when closer to the next segment', () => {
+    // Gap between 200 and 300. ts=290 is 90 from prev.end and 10 from next.start
+    expect(snapToCoverage(290, SEGMENTS)).toBe(300);
+  });
+
+  it('snaps to prev.end_ts when equidistant (tie goes to prev)', () => {
+    // Gap 200–300, midpoint 250: distance to prev.end = 50, to next.start = 50
+    // Condition: (ts - prev.end_ts) <= (next.start_ts - ts) → 50 <= 50 → true → prev.end
+    expect(snapToCoverage(250, SEGMENTS)).toBe(200);
+  });
+
+  it('snaps correctly in a later gap (400–600)', () => {
+    // ts=410 is 10 from prev.end=400, 190 from next.start=600
+    expect(snapToCoverage(410, SEGMENTS)).toBe(400);
+    // ts=590 is 190 from prev.end=400, 10 from next.start=600
+    expect(snapToCoverage(590, SEGMENTS)).toBe(600);
+  });
+});
+
+describe('snapToCoverage — before all segments', () => {
+  it('snaps to first segment start_ts when ts is before the first segment', () => {
+    expect(snapToCoverage(50, SEGMENTS)).toBe(100);
+    expect(snapToCoverage(0, SEGMENTS)).toBe(100);
+  });
+});
+
+describe('snapToCoverage — after all segments', () => {
+  it('snaps to last segment end_ts when ts is after the last segment', () => {
+    expect(snapToCoverage(750, SEGMENTS)).toBe(700);
+    expect(snapToCoverage(9999, SEGMENTS)).toBe(700);
+  });
+});
+
+describe('snapToCoverage — empty / null inputs', () => {
+  it('returns ts unchanged for an empty array', () => {
+    expect(snapToCoverage(500, [])).toBe(500);
+  });
+
+  it('returns ts unchanged for null segments', () => {
+    expect(snapToCoverage(500, null)).toBe(500);
+  });
+
+  it('returns ts unchanged for undefined segments', () => {
+    expect(snapToCoverage(500, undefined)).toBe(500);
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,11 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './src/test/setup.js',
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## Summary

- Wires the existing `snapToCoverage()` function (correct, fully implemented, previously uncalled) into three cursor-setting call sites in `App.jsx`
- Adds `segmentsRef` to expose `timelineData.segments` inside functional updaters without stale closures
- 12 passing unit tests for `snapToCoverage` in `frontend/src/test/snapToCoverage.test.js`

## Problem

`snapToCoverage()` existed in `App.jsx` with a detailed docstring and correct binary-search implementation, but was never called. As a result:

- Clicking into a coverage gap set `cursorTs` to a timestamp with no recording → 404 preview, video player loaded with no segment
- Autoplay advanced through gaps at normal speed with no visual feedback
- The user had no indication the cursor was in dead space

## Changes

### `segmentsRef` (new ref mirror)

```js
const segmentsRef = useRef([]);
useEffect(() => { segmentsRef.current = timelineData?.segments ?? []; }, [timelineData]);
```

Required because `timelineData` is React state and cannot be safely read inside `setCursorTs` functional updaters (stale closure risk). Follows the same pattern as `latestCameraTsRef` directly above it.

### handleSeek

```js
// Before
setCursorTs(ts);
// After
setCursorTs(snapToCoverage(ts, segmentsRef.current));
```

### handlePan

```js
// Before
setCursorTs(prev => Math.min(prev + deltaSec, ceiling));
// After
setCursorTs(prev => {
  const next = Math.min(prev + deltaSec, ceiling);
  return snapToCoverage(next, segmentsRef.current);
});
```

### RAF autoplay tick

```js
// Before
return Math.min(prev + advanceSec, ceiling);
// After
const next = Math.min(prev + advanceSec, ceiling);
return snapToCoverage(next, segmentsRef.current);
```

### Not changed

`navigateEvent` — jumps directly to `start_ts` which is always inside a segment. Snapping would be a no-op and adds noise.

`snapToCoverage` itself — returns `ts` unchanged when `!segments?.length`, so all three call sites are safe when `timelineData` is null or segments is empty.

## Tests

`snapToCoverage.test.js` (12 tests):

| Case | Expected |
|------|----------|
| ts inside segment | unchanged |
| ts at start_ts / end_ts boundary | unchanged |
| gap, closer to prev.end | snaps to prev.end_ts |
| gap, closer to next.start | snaps to next.start_ts |
| gap, equidistant (tie) | snaps to prev.end_ts |
| later gap (400–600) | both directions correct |
| before all segments | snaps to first start_ts |
| after all segments | snaps to last end_ts |
| empty array | unchanged |
| null / undefined | unchanged |

Note: also includes Vitest harness files (`setup.js`, updated `package.json` / `vite.config.js`) that mirror PR #100 (`feat/frontend-test-harness`, not yet merged). When #100 merges, this PR will have a trivial conflict on those three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)