### PR TITLE
fix(videoplayer): close readyState TOCTOU race in preload swap by attaching listener first

### DIFF
--- a/frontend/src/components/VideoPlayer.jsx
+++ b/frontend/src/components/VideoPlayer.jsx
@@ -436,11 +436,19 @@ export default function VideoPlayer({
               });
           };
 
+          // Attach first to close the TOCTOU window, then call immediately if ready.
+          // If readyState drops from >= 1 to 0 between the check and listener
+          // attachment (concurrent destroyHls), doSeekAndPlay would never fire.
+          // Attaching unconditionally guarantees exactly-once delivery.
+          video.addEventListener('loadedmetadata', doSeekAndPlay, { once: true });
           if (video.readyState >= 1) {
+            // Already have metadata — fire now; remove the { once } listener first
+            // so it does not double-fire if a loadedmetadata event follows.
+            video.removeEventListener('loadedmetadata', doSeekAndPlay);
             doSeekAndPlay();
-          } else {
-            video.addEventListener('loadedmetadata', doSeekAndPlay, { once: true });
           }
+          // TODO: Vitest test — preload swap calls doSeekAndPlay when readyState
+          // drops to 0 after the conditional check (requires fake MediaElement).
 
           return () => { destroyHls(); };
         }


### PR DESCRIPTION
## Summary

Reorders the `readyState` check and `loadedmetadata` listener attachment in the HLS preload swap path so the listener is always attached first. One logic change, no new state.

## Problem (TOCTOU race)

```js
// Before — vulnerable window between check and addEventListener
if (video.readyState >= 1) {
  doSeekAndPlay();          // ← safe path
} else {
  video.addEventListener('loadedmetadata', doSeekAndPlay, { once: true });
}
```

If a concurrent `destroyHls()` call drops `readyState` from `>= 1` to `0` in the JavaScript execution gap between the `if` evaluation and the `else` branch's `addEventListener`, neither branch fires `doSeekAndPlay` and playback silently stalls.

## Fix

```js
// After — listener attached first, TOCTOU window eliminated
video.addEventListener('loadedmetadata', doSeekAndPlay, { once: true });
if (video.readyState >= 1) {
  // Already have metadata — remove before calling so the event path
  // cannot double-fire if loadedmetadata follows.
  video.removeEventListener('loadedmetadata', doSeekAndPlay);
  doSeekAndPlay();
}
```

Standard browser pattern: attach unconditionally, then call immediately if the condition is already met. `doSeekAndPlay` fires exactly once in all cases:

| Scenario | Result |
|----------|--------|
| `readyState >= 1` at check time | listener removed, called directly |
| `readyState == 0` at check time, event fires later | `{ once }` fires it |
| `readyState` drops to 0 after check (the race) | `{ once }` fires it |
| `destroyHls` cleans up before metadata arrives | listener leaks, but that path already calls `destroyHls` which tears down the element anyway |

## Tests

No automated test — requires a fake `MediaElement` that can change `readyState` mid-flight. TODO comment added at the call site:
```js
// TODO: Vitest test — preload swap calls doSeekAndPlay when readyState
// drops to 0 after the conditional check (requires fake MediaElement).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)