### PR TITLE
fix(frontend): memoize LabelFilterPills to prevent 60fps reconciliation during autoplay

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -90,9 +90,11 @@ function toDatetimeLocal(ts) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
+// React.memo: LabelFilterPills props change only on label toggle or
+// timeline data refresh, not on every 60fps cursorTs update.
 // TODO: unit test — verify labelCounts updates when timelineData changes,
 // and that count badges show 0 for labels with no events in range.
-function LabelFilterPills({ availableLabels, activeLabels, onToggle, onToggleAll, labelCounts = {}, isMobile }) {
+const LabelFilterPills = React.memo(function LabelFilterPills({ availableLabels, activeLabels, onToggle, onToggleAll, labelCounts = {}, isMobile }) {
   if (!availableLabels?.length) return null;
   const allActive = activeLabels === null;
 
@@ -132,7 +134,7 @@ function LabelFilterPills({ availableLabels, activeLabels, onToggle, onToggleAll
       })}
     </div>
   );
-}
+});
 
 export default function App() {
   const isMobile = useIsMobile();


### PR DESCRIPTION
## Summary

- Wraps `LabelFilterPills` in `React.memo()` to prevent unnecessary re-renders during autoplay
- App.jsx calls `setCursorTs` at ~60fps during autoplay; without memo, every update caused a DOM reconciliation pass over all pill buttons even though their props hadn't changed
- All props were already referentially stable: `availableLabels` (useMemo), `activeLabels` (Set state), `onToggle`/`onToggleAll` (useCallback), `labelCounts` (useMemo), `isMobile` (boolean) — so memo is fully effective

## Test plan

- [ ] Label pills still toggle correctly when clicked
- [ ] "all" button still resets filter
- [ ] Count badges still update when the timeline range changes
- [ ] During autoplay, verify in React DevTools Profiler that `LabelFilterPills` no longer appears in the flame chart on every frame

No automated tests added — this is a pure performance/memoization change with no behavioural difference; the TODO for unit-testing `labelCounts` updates remains in the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)