### PR TITLE
M4 complete: slot scheduler with prefetch + 5 bug fixes

### DIFF
--- a/CLAUDE_CHROME_TEST_PROMPT.md
+++ b/CLAUDE_CHROME_TEST_PROMPT.md
@@ -1,0 +1,189 @@
+# Claude Chrome Testing Prompt
+
+Paste the block below into Claude with browser/computer access (e.g. Claude.ai with a screen-sharing or browser-use tool active). It gives Claude enough context to drive the full test run autonomously.
+
+---
+
+## Prompt (copy everything below this line)
+
+---
+
+You are testing **Frigate Review Accelerator** — a real-time surveillance footage review app built on Frigate NVR. The app is running at `https://frigatebird.pondhouse.cloud`.
+
+Your job is to work through the test checklist below systematically. For each item:
+1. Perform the action or observation described
+2. Record PASS, FAIL, or SKIP with a one-line note
+3. If something fails, capture the exact error text or unexpected behaviour before moving on
+4. At the end, produce a summary table of all results
+
+Do not stop on failures — continue through all items and report everything at the end.
+
+---
+
+### App overview (read before testing)
+
+The app has three panels:
+- **Left** — a vertical timeline wheel (Pixi.js canvas). Slots represent time buckets. The center row is the current cursor position.
+- **Right** — a video/preview panel showing either a live JPEG feed, a still frame preview, or an HLS recording playback
+- **Header** — camera selector, socket status badge, freshness badge, playback state badge, slot count (e.g. `60/60 · 8B 52A`), and a Debug button
+
+Key terms:
+- **Slot** — one time bucket in the 60-slot timeline. Strategy A = FFmpeg frame, Strategy B = Frigate event snapshot (semantic best candidate)
+- **Freshness** — MQTT connection state: `live` / `recovering` / `stale`
+- **tWheel** — total visible time span. Below 5 minutes = Type A only. Above 5 minutes = Type B preferred
+- **Slot grid** — the grid of thumbnail images below the video panel (visible without Debug)
+- **Debug overlay** — detailed table, toggled with the Debug button
+
+---
+
+### Setup checks (do these first)
+
+1. Navigate to `https://frigatebird.pondhouse.cloud`
+2. Open the browser console (DevTools → Console tab)
+3. Check: no red errors on load
+4. Check: socket status badge in header says **connected**
+5. Check: freshness badge says **live** within 5 seconds of load
+6. Note the current slot count displayed in the header
+
+---
+
+### M1 — Timeline & Frame Extraction
+
+**Initial load**
+7. Note the time from page load to first slots appearing in the slot grid (target: under 1.5s)
+8. Note the time for all 60 slots to fill (target: under 6s)
+9. Confirm slots filled center-out — middle thumbnails appeared before edge thumbnails
+10. Confirm header reads **60/60** when complete
+11. Confirm no solid white or solid grey frames in the slot grid (every slot should have a real image or a colored mock placeholder)
+
+**Zoom**
+12. Click the **+** zoom button once — confirm the range label in the debug table narrows and slots re-resolve
+13. Click **+** several more times to reach the tightest zoom — confirm the header shows **0B** (all Type A)
+14. Click **−** to zoom out past 5 minutes — confirm header shows **B count > 0** (Type B slots appear, assuming there are Frigate events in the current window)
+15. Confirm cached slots return instantly on zoom (no re-extraction delay for already-loaded slots)
+
+**Scroll**
+16. Use the mouse wheel over the timeline canvas — confirm the cursor row steps by one slot per scroll threshold
+17. Confirm a "Scrubbing..." label briefly appears in the playback controls after scrolling, then disappears within ~400ms
+18. Click a row in the timeline canvas — confirm the cursor jumps to that slot's time
+
+**Live mode**
+19. On load, confirm the video panel shows a live JPEG image with a **LIVE** badge
+20. Scroll the timeline away from the current time — confirm the live feed stops and a preview frame appears
+21. Wait 5 seconds without interacting — confirm the live feed resumes automatically
+
+---
+
+### M2 — Type B Semantic Hydration
+
+22. With zoom ≥ 5 minutes, check the slot grid — confirm some thumbnails have a coloured top border or "B" label indicating Type B strategy
+23. In the timeline wheel, confirm B slots show a small Lucide icon (person, car, dog, etc.) to the right of the time label, with a coloured dot
+24. Click **Debug** → look at the Slot Detail table → confirm B rows show a score value (e.g. `42%`), not `-`
+25. Check the header slot count — it should read something like `60/60 · 8B 52A` (exact numbers will vary by time of day and camera activity)
+
+---
+
+### M4 — Playback
+
+26. Scroll the timeline back in time to a slot that has a recording (non-live time, should show a frame image not a placeholder)
+27. Click **Play Recording**
+28. Confirm the video panel switches from the still preview image to a playing video (HLS stream)
+29. Confirm the video plays without buffering errors in the console
+30. Watch the cursor for 5–10 seconds — confirm it **advances** as the video plays (the center row of the timeline wheel moves down toward PRESENT)
+31. Confirm the time readout in the playback controls (bottom of video panel) updates as the cursor advances
+32. Click **Pause** — confirm the video pauses and the cursor stops moving
+33. Confirm the playback state badge changes to **SCRUB REVIEW** after pausing
+34. Click **Play Recording** again — confirm video resumes and cursor continues advancing (does not jump back to original start time)
+35. Scroll to a different slot position, click **Play Recording** again — confirm video starts from the new timestamp
+
+---
+
+### Debug overlay
+
+36. Click **Debug** — confirm the overlay table appears with rows for: Camera, Socket, Freshness, Playback, Scrubbing, Cursor, Range, Viewport, Slots, Playing, VOD URL, Preview
+37. Scroll the timeline while Debug is open — confirm the Cursor and Viewport rows update in real time
+38. Confirm the Slot Detail table at the bottom shows columns: #, Strategy, Score, Entity, Status
+39. Confirm B-strategy rows are visually distinct from A rows
+
+---
+
+### Camera switching
+
+40. Change the camera using the selector in the header
+41. Confirm the slot grid clears and reloads for the new camera (new thumbnails, not the same frames)
+42. Confirm the live view in the video panel switches to the new camera feed
+43. Confirm **Play Recording** works on the new camera
+
+---
+
+### Edge cases
+
+44. Select a camera that is unlikely to have recent recordings (pick one from the bottom of the list)
+45. Confirm the app does not crash — placeholder frames or mock images should appear, no JS errors
+46. Scroll the timeline far into the past (several hours) — confirm the app loads without errors
+47. Rapidly click **+** and **−** zoom buttons 10 times quickly — confirm no crash and no duplicate or mismatched slot batches when it settles
+
+---
+
+### Media service API checks (run these in the browser console via fetch)
+
+Run each of these in the DevTools console. They test the Python media service directly.
+
+**Health check:**
+```javascript
+fetch('https://frigatebird.pondhouse.cloud/api-media/health')
+  .then(r => r.json()).then(console.log)
+```
+48. Confirm response includes `"ok": true` and `"frigate_reachable": true`
+
+**Preview strip** (replace CAMERA and timestamps with real values):
+```javascript
+fetch('https://frigatebird.pondhouse.cloud/api-media/preview/strip', {
+  method: 'POST',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify({
+    camera: 'street-doorbell',
+    start_time: Math.floor(Date.now()/1000) - 300,
+    end_time: Math.floor(Date.now()/1000) - 60,
+    count: 12
+  })
+}).then(r => r.json()).then(console.log)
+```
+49. Confirm response includes `"ok": true` and a `"url"` path ending in `.webp`
+50. Open the returned URL in a new tab — confirm it loads a wide filmstrip image (12 frames side by side)
+
+**Clip prepare:**
+```javascript
+fetch('https://frigatebird.pondhouse.cloud/api-media/clip/prepare', {
+  method: 'POST',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify({
+    camera: 'street-doorbell',
+    start_time: Math.floor(Date.now()/1000) - 300,
+    end_time: Math.floor(Date.now()/1000) - 240
+  })
+}).then(r => r.json()).then(console.log)
+```
+51. Confirm response includes `"ok": true`, `"status": "ready"`, and a `"clip_url"` path ending in `.mp4`
+52. Open the returned clip URL — confirm it plays as a video
+
+---
+
+### Final report
+
+After completing all 52 checks, output a results table in this format:
+
+| # | Test | Result | Notes |
+|---|------|--------|-------|
+| 1 | No console errors on load | PASS | |
+| 2 | Socket badge: connected | PASS | |
+| ... | | | |
+
+Then write a short paragraph summarising:
+- Total PASS / FAIL / SKIP counts
+- Any patterns in failures (e.g. all API checks failed → likely a proxy config issue)
+- Recommended next steps for any failures
+
+---
+
+**Note on API paths:** The fetch URLs above assume nginx proxy manager is routing `/api-media/` to the Python media service on port 4020. If the proxy path differs on your setup, adjust accordingly. The core Socket.IO server is on port 4010 and the frontend on port 5173 — both proxied through nginx at the same domain.

--- a/apps/core-server/src/adapters/frigate-entity-normalizer.ts
+++ b/apps/core-server/src/adapters/frigate-entity-normalizer.ts
@@ -65,7 +65,7 @@ export function normalizeFrigateEvent(raw: FrigateRawEvent): SemanticEntity {
     stationary,
     positionChanges: null,
     currentZones: raw.zones ?? [],
-    enteredZones: raw.zones ?? [],
+    enteredZones: raw.entered_zones ?? raw.zones ?? [],
     snapshot: {
       available: raw.has_snapshot,
       frameTime: raw.start_time,

--- a/apps/core-server/src/adapters/frigate-http-client.ts
+++ b/apps/core-server/src/adapters/frigate-http-client.ts
@@ -8,6 +8,7 @@ export interface FrigateRawEvent {
   label: string;
   sub_label?: string | null;
   zones: string[];
+  entered_zones?: string[];
   start_time: number;
   end_time: number | null;
   has_clip: boolean;

--- a/apps/core-server/src/persistence/entity-store.ts
+++ b/apps/core-server/src/persistence/entity-store.ts
@@ -47,8 +47,8 @@ function rowToEntity(row: Record<string, unknown>): SemanticEntity {
     stationary:
       row.stationary != null ? (row.stationary as number) === 1 : null,
     positionChanges: (row.position_changes as number | null) ?? null,
-    currentZones: JSON.parse((row.current_zones_json as string) ?? "[]"),
-    enteredZones: JSON.parse((row.entered_zones_json as string) ?? "[]"),
+    currentZones: JSON.parse((row.current_zones_json as string) || "[]"),
+    enteredZones: JSON.parse((row.entered_zones_json as string) || "[]"),
     snapshot: {
       available: (row.snapshot_available as number) === 1,
       frameTime: (row.snapshot_frame_time as number | null) ?? null,

--- a/apps/core-server/src/realtime/socket.ts
+++ b/apps/core-server/src/realtime/socket.ts
@@ -6,7 +6,8 @@ import type {
   SlotResolvedEvent,
 } from "@frigate-review/shared-types";
 import { ViewportSession } from "./viewport-session.js";
-import { resolveSlotBatch, resolveSlotBatchProgressive } from "../timeline/slot-resolver.js";
+import { resolveSlotBatch, resolveSlotBatchProgressive, prefetchSlots } from "../timeline/slot-resolver.js";
+import { computePrefetchSlots } from "../timeline/slot-scheduler.js";
 import { SemanticIndex } from "../semantic/semantic-index.js";
 import { backfillViewportRange } from "../services/http-backfill.js";
 import { getMqttStatus } from "../adapters/frigate-mqtt-ingestor.js";
@@ -182,6 +183,22 @@ async function resolveAndEmitBatch(socket: any, session: ViewportSession): Promi
       });
     },
   );
+
+  if (session.currentGeneration() !== gen) return;
+
+  // Background prefetch: resolve adjacent slots into cache so scroll interactions
+  // get immediate cache hits. Priority order: PREFETCH_FORWARD before PREFETCH_BACKWARD.
+  // Cancelled automatically when the viewport changes (generation check).
+  const prefetch = computePrefetchSlots(session.viewport);
+  const camera = session.viewport.cameraIds[0];
+
+  socket.emit("prefetch:state", {
+    viewportId: session.viewport.viewportId,
+    totalQueued: prefetch.length,
+    strategy: "active",
+  });
+
+  await prefetchSlots(camera, prefetch, session.cache, () => session.currentGeneration() !== gen);
 
   if (session.currentGeneration() === gen) {
     socket.emit("prefetch:state", {

--- a/apps/core-server/src/semantic/semantic-index.ts
+++ b/apps/core-server/src/semantic/semantic-index.ts
@@ -2,9 +2,6 @@ import type { SemanticEntity, EventId, CameraName } from "@frigate-review/shared
 
 const BUCKET_SIZE_SEC = 60; // 60-second time buckets
 
-function timeBucketKey(timestamp: number): string {
-  return String(Math.floor(timestamp / BUCKET_SIZE_SEC));
-}
 
 function overlaps(
   entityStart: number,
@@ -13,7 +10,7 @@ function overlaps(
   slotEnd: number,
 ): boolean {
   const effectiveEnd = entityEnd ?? Number.POSITIVE_INFINITY;
-  return entityStart < slotEnd && effectiveEnd >= slotStart;
+  return entityStart < slotEnd && effectiveEnd > slotStart;
 }
 
 export class SemanticIndex {
@@ -133,12 +130,22 @@ export class SemanticIndex {
       this.byZone.get(zone)!.add(entity.id);
     }
 
-    // Time bucket index — index by start time bucket
-    const bucket = timeBucketKey(entity.startTime);
-    if (!this.byTimeBucket.has(bucket)) {
-      this.byTimeBucket.set(bucket, new Set());
+    // Index every bucket the entity is active in so long-running entities (e.g. a car
+    // present for hours) remain candidates for queries anywhere in their lifetime.
+    // Ongoing entities (endTime = null) are indexed only at their start bucket — they
+    // are still active so queries near "now" will find them via the ±1 margin.
+    const startBucket = Math.floor(entity.startTime / BUCKET_SIZE_SEC);
+    const endBucket =
+      entity.endTime != null
+        ? Math.floor(entity.endTime / BUCKET_SIZE_SEC)
+        : startBucket;
+    for (let b = startBucket; b <= endBucket; b++) {
+      const key = String(b);
+      if (!this.byTimeBucket.has(key)) {
+        this.byTimeBucket.set(key, new Set());
+      }
+      this.byTimeBucket.get(key)!.add(entity.id);
     }
-    this.byTimeBucket.get(bucket)!.add(entity.id);
   }
 
   private removeFromIndices(entity: SemanticEntity): void {
@@ -149,7 +156,13 @@ export class SemanticIndex {
       this.byZone.get(zone)?.delete(entity.id);
     }
 
-    const bucket = timeBucketKey(entity.startTime);
-    this.byTimeBucket.get(bucket)?.delete(entity.id);
+    const startBucket = Math.floor(entity.startTime / BUCKET_SIZE_SEC);
+    const endBucket =
+      entity.endTime != null
+        ? Math.floor(entity.endTime / BUCKET_SIZE_SEC)
+        : startBucket;
+    for (let b = startBucket; b <= endBucket; b++) {
+      this.byTimeBucket.get(String(b))?.delete(entity.id);
+    }
   }
 }

--- a/apps/core-server/src/timeline/slot-resolver.ts
+++ b/apps/core-server/src/timeline/slot-resolver.ts
@@ -8,6 +8,7 @@ import { SemanticIndex } from "../semantic/semantic-index.js";
 import { resolveTypeB } from "./type-b-resolver.js";
 import { extractFrameBatch } from "../services/media-client.js";
 import { SlotCache } from "./slot-cache.js";
+import type { ScheduledSlot } from "./slot-scheduler.js";
 
 const SEMANTIC_THRESHOLD_SEC = 300; // 5 minutes — below this, Type A only
 const PROGRESSIVE_CHUNK_SIZE = 15;  // Type A slots per HTTP call to media-service
@@ -154,6 +155,60 @@ async function _resolveTypeAChunk(
   }
 
   return results;
+}
+
+/**
+ * Prefetch adjacent slots into the TypeScript cache without emitting to clients.
+ *
+ * Processes PREFETCH_FORWARD entries before PREFETCH_BACKWARD (they arrive in
+ * that order from computePrefetchSlots). Skips slots already in cache.
+ * Returns early when isCancelled() returns true (viewport changed).
+ *
+ * Only Type A is used for prefetch — Type B will be resolved when the slot
+ * becomes visible if the zoom level calls for it.
+ */
+export async function prefetchSlots(
+  camera: string,
+  scheduledSlots: ScheduledSlot[],
+  cache: SlotCache,
+  isCancelled: () => boolean,
+): Promise<number> {
+  let fetched = 0;
+
+  for (let i = 0; i < scheduledSlots.length; i += PROGRESSIVE_CHUNK_SIZE) {
+    if (isCancelled()) break;
+
+    const chunk = scheduledSlots.slice(i, i + PROGRESSIVE_CHUNK_SIZE);
+    const uncached = chunk.filter(
+      (e) => !cache.getBestForTime(camera, e.slot.tSlotCenter),
+    );
+    if (uncached.length === 0) continue;
+
+    const timestamps = uncached.map((e) => e.slot.tSlotCenter);
+    try {
+      const batchResults = await extractFrameBatch(camera, timestamps);
+      for (let j = 0; j < uncached.length; j++) {
+        const entry = uncached[j];
+        const frameResult = batchResults[j];
+        if (frameResult) {
+          cache.put(camera, entry.slot.tSlotCenter, {
+            viewportId: "",
+            slotIndex: entry.slot.index,
+            resolvedStrategy: "A",
+            mediaUrl: frameResult.media_url,
+            sourceTimestamp: frameResult.resolved_timestamp,
+            cacheHit: frameResult.cache_hit,
+            status: "clean",
+          });
+          fetched++;
+        }
+      }
+    } catch {
+      // Prefetch failures are silent — best-effort operation
+    }
+  }
+
+  return fetched;
 }
 
 /**

--- a/apps/core-server/src/timeline/slot-scheduler.ts
+++ b/apps/core-server/src/timeline/slot-scheduler.ts
@@ -1,0 +1,72 @@
+import type { TimelineViewport, TimelineSlot } from "@frigate-review/shared-types";
+
+/**
+ * Priority levels for slot resolution work.
+ * Lower number = higher priority.
+ *
+ * VISIBLE  — slots currently in the viewport (resolved inline, not queued)
+ * DIRTY    — slots invalidated by MQTT events (resolved immediately by slot-invalidator)
+ * PREFETCH_FORWARD  — adjacent slots ahead of the viewport (background)
+ * PREFETCH_BACKWARD — adjacent slots behind the viewport (background, lowest priority)
+ */
+export const SlotPriority = {
+  VISIBLE: 0,
+  DIRTY: 1,
+  PREFETCH_FORWARD: 2,
+  PREFETCH_BACKWARD: 3,
+} as const;
+
+export type SlotPriority = (typeof SlotPriority)[keyof typeof SlotPriority];
+
+export interface ScheduledSlot {
+  slot: TimelineSlot;
+  priority: SlotPriority;
+}
+
+/** Number of slots to prefetch in each direction beyond the viewport. */
+const PREFETCH_COUNT = 30;
+
+/**
+ * Compute slots adjacent to the current viewport for background prefetch.
+ *
+ * Returns PREFETCH_FORWARD slots first (nearest to viewport edge first),
+ * followed by PREFETCH_BACKWARD slots (nearest to viewport edge first).
+ * This ordering ensures the scheduler processes forward slots before backward
+ * ones, matching the natural forward-motion scroll pattern.
+ */
+export function computePrefetchSlots(viewport: TimelineViewport): ScheduledSlot[] {
+  const { tViewEnd, tViewStart, tDiv } = viewport;
+  const results: ScheduledSlot[] = [];
+
+  // PREFETCH_FORWARD: slots after tViewEnd, nearest first
+  for (let i = 0; i < PREFETCH_COUNT; i++) {
+    const tSlotStart = tViewEnd + i * tDiv;
+    const tSlotEnd = tSlotStart + tDiv;
+    results.push({
+      slot: {
+        index: 60 + i,
+        tSlotStart,
+        tSlotEnd,
+        tSlotCenter: (tSlotStart + tSlotEnd) / 2,
+      },
+      priority: SlotPriority.PREFETCH_FORWARD,
+    });
+  }
+
+  // PREFETCH_BACKWARD: slots before tViewStart, nearest first
+  for (let i = 0; i < PREFETCH_COUNT; i++) {
+    const tSlotEnd = tViewStart - i * tDiv;
+    const tSlotStart = tSlotEnd - tDiv;
+    results.push({
+      slot: {
+        index: -1 - i,
+        tSlotStart,
+        tSlotEnd,
+        tSlotCenter: (tSlotStart + tSlotEnd) / 2,
+      },
+      priority: SlotPriority.PREFETCH_BACKWARD,
+    });
+  }
+
+  return results;
+}

--- a/apps/media-service/app/services/ffmpeg_extractor.py
+++ b/apps/media-service/app/services/ffmpeg_extractor.py
@@ -145,7 +145,7 @@ async def _http_clip_fallback(
     clip_start = int(timestamp) - 1
     clip_end   = clip_start + 11
     clip_url   = f"{FRIGATE_URL}/api/{camera}/start/{clip_start}/end/{clip_end}/clip.mp4"
-    clip_path  = os.path.join(tmpdir, f"clip_{timestamp:.0f}.mp4")
+    clip_path  = os.path.join(tmpdir, f"clip_{timestamp:.3f}.mp4")
     out_path   = os.path.join(tmpdir, f"fb_{timestamp:.3f}.{fmt}")
 
     try:

--- a/todo.md
+++ b/todo.md
@@ -53,7 +53,16 @@
 - [x] Clip export endpoint (POST /clip/prepare — local concat + Frigate HTTP fallback)
 - [x] Debug overlay (slot index, strategy A/B, score, cache hit, entity ID)
 - [x] prefetch:state dev feedback event (emitted after resolveAndEmitBatch completes)
-- [ ] Performance tuning — scheduler priority (VISIBLE > DIRTY > PREFETCH_FORWARD > PREFETCH_BACKWARD)
+- [x] Performance tuning — scheduler priority (VISIBLE > DIRTY > PREFETCH_FORWARD > PREFETCH_BACKWARD)
+
+---
+
+## Bug Fixes Applied
+- [x] SemanticIndex: long-running entities missed by time-bucket lookup (only startTime was indexed; now indexes all buckets from start to end)
+- [x] SemanticIndex: `overlaps()` used `>=` instead of `>` — entities ending exactly at a slot boundary were incorrectly included
+- [x] FrigateRawEvent: missing `entered_zones` field; `enteredZones` always mirrored `currentZones`, losing cumulative zone history
+- [x] entity-store: `??` doesn't guard against empty string in JSON.parse; changed to `||`
+- [x] ffmpeg_extractor: HTTP fallback clip filename used `:.0f` (rounds to integer), causing filename collision and potential file corruption for concurrent nearby timestamps
 
 ---
 


### PR DESCRIPTION
## Summary

- Implements the final M4 item: slot scheduler with `VISIBLE > DIRTY > PREFETCH_FORWARD > PREFETCH_BACKWARD` priority ordering
- Fixes 5 bugs found during code review

## Scheduler (closes M4)

**New `slot-scheduler.ts`** — exports `SlotPriority` enum and `computePrefetchSlots(viewport)`, which generates 30 forward + 30 backward slots adjacent to the current viewport, forward-first.

**`slot-resolver.ts`** — new `prefetchSlots()` function resolves Type A frames into the TypeScript `SlotCache` silently (no client emission). Processes in 15-slot chunks and stops early if `isCancelled()` returns true (viewport changed).

**`socket.ts`** — `resolveAndEmitBatch()` now kicks off background prefetch after visible slots resolve, emitting `prefetch:state` with `strategy: "active"` + count when running, `strategy: "idle"` when done or cancelled.

Priority ordering is satisfied by design: VISIBLE resolved inline → DIRTY resolved immediately by slot-invalidator (separate path) → PREFETCH_FORWARD → PREFETCH_BACKWARD.

## Bug Fixes

| Severity | File | Bug |
|---|---|---|
| High | `semantic-index.ts` | Entities only indexed by `startTime` bucket — long-running entities (parked car, persistent detection) were invisible to Type B queries for any slot outside their start minute. Now indexes every bucket in `[startBucket, endBucket]`. |
| Low | `semantic-index.ts` | `overlaps()` used `>=` instead of `>` — entities ending exactly at a slot boundary were incorrectly included. Slots are half-open `[start, end)`. |
| Medium | `frigate-http-client.ts` / `frigate-entity-normalizer.ts` | `FrigateRawEvent` was missing `entered_zones`; `enteredZones` always mirrored `currentZones`, losing cumulative zone history. Added field and wired it up. |
| Low | `entity-store.ts` | `??` doesn't guard against empty string `""` in `JSON.parse` — only protects against `null`/`undefined`. Changed to `\|\|`. |
| Medium | `ffmpeg_extractor.py` | HTTP fallback clip filename used `:.0f` (rounds to nearest integer), so timestamps like `1000.3` and `1000.7` both produced `clip_1000.mp4`. Concurrent curl processes writing the same path corrupt the file. Changed to `:.3f`. |

## Test plan

- [ ] Load timeline, observe `prefetch:state` events in console: `strategy: "active"` with `totalQueued: 60` after first paint, then `strategy: "idle"` when done
- [ ] Scroll forward — slots that were prefetched should show as `cacheHit: true` in debug overlay
- [ ] Trigger a Frigate detection event — dirty slot should resolve and appear before any remaining prefetch work completes
- [ ] Verify long-running entity (stationary object present > 2 min) appears in Type B slots throughout its lifetime, not just in the first minute
- [ ] Run TESTING.md checklist to confirm no M1–M4 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)