### PR TITLE
HTTPS proxy fixes + updated test prompt

### DIFF
--- a/CLAUDE_CHROME_TEST_PROMPT.md
+++ b/CLAUDE_CHROME_TEST_PROMPT.md
@@ -1,6 +1,6 @@
 # Claude Chrome Testing Prompt
 
-Paste the block below into Claude with browser/computer access (e.g. Claude.ai with a screen-sharing or browser-use tool active). It gives Claude enough context to drive the full test run autonomously.
+Paste the block below into Claude with browser access. It gives Claude full context to drive the test run autonomously across both the local network and the public nginx URL.
 
 ---
 
@@ -8,135 +8,217 @@ Paste the block below into Claude with browser/computer access (e.g. Claude.ai w
 
 ---
 
-You are testing **Frigate Review Accelerator** — a real-time surveillance footage review app built on Frigate NVR. The app is running at `https://frigatebird.pondhouse.cloud`.
+You are testing **Frigate Review Accelerator** — a real-time surveillance footage review app built on Frigate NVR.
 
-Your job is to work through the test checklist below systematically. For each item:
-1. Perform the action or observation described
-2. Record PASS, FAIL, or SKIP with a one-line note
-3. If something fails, capture the exact error text or unexpected behaviour before moving on
-4. At the end, produce a summary table of all results
+Before testing, read the source code at:
+**https://github.com/helicopterrun/frigate-review-accelerator**
 
-Do not stop on failures — continue through all items and report everything at the end.
+Focus on: `apps/frontend/src/`, `apps/core-server/src/`, `apps/media-service/app/`, and `TESTING.md` in the repo root. Understanding the code will help you identify root causes rather than just surface symptoms.
 
 ---
 
-### App overview (read before testing)
+### Two environments to test
+
+| Environment | URL | Notes |
+|---|---|---|
+| **Local (LAN)** | `http://192.168.50.207:5173/` | Direct Vite dev server. No nginx. Use this to isolate frontend-only issues. |
+| **Public (nginx)** | `https://frigatebird.pondhouse.cloud/` | Proxied through nginx proxy manager. Tests HTTPS, Socket.IO proxy, and media proxy. |
+
+Test **both** environments. Many failures in the public URL that pass on local indicate a proxy configuration issue, not a code bug.
+
+---
+
+### Infrastructure reference
+
+| Service | Local address | Expected nginx proxy path |
+|---|---|---|
+| Frontend (Vite) | `http://192.168.50.207:5173` | `/` (catch-all) |
+| Core server (Socket.IO) | `http://192.168.50.207:4010` | `/socket.io/` → `localhost:4010` |
+| Media service (FastAPI) | `http://192.168.50.207:4020` | `/api-media/` → `localhost:4020` |
+| Frigate NVR | `http://192.168.50.207:5000` | `/frigate/` → `localhost:5000` |
+
+---
+
+### App overview
 
 The app has three panels:
-- **Left** — a vertical timeline wheel (Pixi.js canvas). Slots represent time buckets. The center row is the current cursor position.
-- **Right** — a video/preview panel showing either a live JPEG feed, a still frame preview, or an HLS recording playback
-- **Header** — camera selector, socket status badge, freshness badge, playback state badge, slot count (e.g. `60/60 · 8B 52A`), and a Debug button
+- **Left** — a vertical timeline wheel (Pixi.js canvas). 60 slots, each representing a time bucket. Center row = cursor position.
+- **Right** — video/preview panel: live JPEG feed, still frame preview, or HLS recording playback
+- **Header** — camera selector, socket status badge (`connected`/`disconnected`/`error`), freshness badge (`live`/`recovering`/`stale`), playback state badge, slot count (e.g. `60/60 · 8B 52A`), Debug button
 
 Key terms:
-- **Slot** — one time bucket in the 60-slot timeline. Strategy A = FFmpeg frame, Strategy B = Frigate event snapshot (semantic best candidate)
-- **Freshness** — MQTT connection state: `live` / `recovering` / `stale`
-- **tWheel** — total visible time span. Below 5 minutes = Type A only. Above 5 minutes = Type B preferred
-- **Slot grid** — the grid of thumbnail images below the video panel (visible without Debug)
-- **Debug overlay** — detailed table, toggled with the Debug button
+- **Slot** — one time bucket. Strategy **A** = FFmpeg-extracted frame. Strategy **B** = Frigate event snapshot (semantic best candidate, only used when zoom ≥ 5 min)
+- **Freshness** — MQTT health: `live` / `recovering` / `stale`
+- **Slot grid** — thumbnail grid below the video panel (always visible)
+- **Debug overlay** — detailed state table, toggled with the Debug button
 
 ---
 
-### Setup checks (do these first)
+### Instructions
 
-1. Navigate to `https://frigatebird.pondhouse.cloud`
-2. Open the browser console (DevTools → Console tab)
-3. Check: no red errors on load
-4. Check: socket status badge in header says **connected**
-5. Check: freshness badge says **live** within 5 seconds of load
-6. Note the current slot count displayed in the header
-
----
-
-### M1 — Timeline & Frame Extraction
-
-**Initial load**
-7. Note the time from page load to first slots appearing in the slot grid (target: under 1.5s)
-8. Note the time for all 60 slots to fill (target: under 6s)
-9. Confirm slots filled center-out — middle thumbnails appeared before edge thumbnails
-10. Confirm header reads **60/60** when complete
-11. Confirm no solid white or solid grey frames in the slot grid (every slot should have a real image or a colored mock placeholder)
-
-**Zoom**
-12. Click the **+** zoom button once — confirm the range label in the debug table narrows and slots re-resolve
-13. Click **+** several more times to reach the tightest zoom — confirm the header shows **0B** (all Type A)
-14. Click **−** to zoom out past 5 minutes — confirm header shows **B count > 0** (Type B slots appear, assuming there are Frigate events in the current window)
-15. Confirm cached slots return instantly on zoom (no re-extraction delay for already-loaded slots)
-
-**Scroll**
-16. Use the mouse wheel over the timeline canvas — confirm the cursor row steps by one slot per scroll threshold
-17. Confirm a "Scrubbing..." label briefly appears in the playback controls after scrolling, then disappears within ~400ms
-18. Click a row in the timeline canvas — confirm the cursor jumps to that slot's time
-
-**Live mode**
-19. On load, confirm the video panel shows a live JPEG image with a **LIVE** badge
-20. Scroll the timeline away from the current time — confirm the live feed stops and a preview frame appears
-21. Wait 5 seconds without interacting — confirm the live feed resumes automatically
+For each numbered test:
+1. Perform the action on **both** environments unless marked LOCAL or PUBLIC only
+2. Record: environment, PASS / FAIL / SKIP, and a one-line note
+3. On failure, capture the exact console error or visual symptom
+4. Do not stop on failures — complete every item
 
 ---
 
-### M2 — Type B Semantic Hydration
+## Part 1 — Setup
 
-22. With zoom ≥ 5 minutes, check the slot grid — confirm some thumbnails have a coloured top border or "B" label indicating Type B strategy
-23. In the timeline wheel, confirm B slots show a small Lucide icon (person, car, dog, etc.) to the right of the time label, with a coloured dot
-24. Click **Debug** → look at the Slot Detail table → confirm B rows show a score value (e.g. `42%`), not `-`
-25. Check the header slot count — it should read something like `60/60 · 8B 52A` (exact numbers will vary by time of day and camera activity)
+Run on both environments.
 
----
+**1.** Navigate to each URL. Confirm the app renders (timeline canvas visible, header present, not a blank page or error screen).
 
-### M4 — Playback
+**2.** Open DevTools console. Record any red errors present immediately on load.
 
-26. Scroll the timeline back in time to a slot that has a recording (non-live time, should show a frame image not a placeholder)
-27. Click **Play Recording**
-28. Confirm the video panel switches from the still preview image to a playing video (HLS stream)
-29. Confirm the video plays without buffering errors in the console
-30. Watch the cursor for 5–10 seconds — confirm it **advances** as the video plays (the center row of the timeline wheel moves down toward PRESENT)
-31. Confirm the time readout in the playback controls (bottom of video panel) updates as the cursor advances
-32. Click **Pause** — confirm the video pauses and the cursor stops moving
-33. Confirm the playback state badge changes to **SCRUB REVIEW** after pausing
-34. Click **Play Recording** again — confirm video resumes and cursor continues advancing (does not jump back to original start time)
-35. Scroll to a different slot position, click **Play Recording** again — confirm video starts from the new timestamp
+**3.** Confirm the socket status badge reads **connected** within 3 seconds.
+- If FAIL on public but PASS on local → nginx `/socket.io/` proxy is missing or missing WebSocket upgrade headers.
+
+**4.** Confirm the freshness badge reads **live** within 5 seconds.
+- If it stays on `recovering` → MQTT is connected but no Frigate events have arrived, or socket never connected.
+
+**5.** Note the slot count in the header.
 
 ---
 
-### Debug overlay
+## Part 2 — Timeline & Frame Extraction (M1)
 
-36. Click **Debug** — confirm the overlay table appears with rows for: Camera, Socket, Freshness, Playback, Scrubbing, Cursor, Range, Viewport, Slots, Playing, VOD URL, Preview
-37. Scroll the timeline while Debug is open — confirm the Cursor and Viewport rows update in real time
-38. Confirm the Slot Detail table at the bottom shows columns: #, Strategy, Score, Entity, Status
-39. Confirm B-strategy rows are visually distinct from A rows
+**6.** Measure time from page load to first slots appearing in the slot grid. Target: under 1.5 seconds.
+
+**7.** Measure time for all 60 slots to fill. Target: under 6 seconds.
+
+**8.** Confirm slots filled center-out — middle thumbnails appeared before edge thumbnails. (Watch carefully or reload and observe.)
+
+**9.** Confirm header reaches **60/60** within the time measured in step 7.
+
+**10.** Confirm no slots are solid white or solid grey — every slot should have either a real camera frame or a coloured mock placeholder (the mock frames have a camera name and timestamp drawn on them).
+
+**11.** Click the **+** zoom button once. Confirm the time range label narrows. Confirm already-loaded slots return instantly (cache hit — no delay).
+
+**12.** Keep clicking **+** to reach the tightest zoom stop. Confirm the header shows **0B** (all slots Type A at tight zoom).
+
+**13.** Click **−** to zoom past 5 minutes total range. Confirm the header shows a non-zero B count (e.g. `8B`) — these are Frigate event snapshots chosen by the semantic resolver.
+- If B count stays 0 even at wide zoom → backfill from Frigate returned no events, or MQTT index is empty. Check Frigate is running.
+
+**14.** Use the mouse wheel over the timeline canvas. Confirm the cursor steps by one slot per scroll threshold (not continuous smooth scroll).
+
+**15.** Confirm a **"Scrubbing..."** label appears in the playback controls immediately after scrolling, then disappears within ~1 second.
+
+**16.** Click a row in the timeline canvas. Confirm the cursor jumps to that slot's timestamp (visible in the debug table Cursor row, or in the time readout).
+
+**17.** On load, confirm the video panel shows a live JPEG image with a **LIVE** badge. (Requires Frigate port 5000 to be reachable — may fail on public if `/frigate/` is not proxied.)
+
+**18.** Scroll the timeline away from NOW. Confirm the LIVE badge disappears and a still preview frame takes its place.
+
+**19.** Wait 5 seconds without touching anything. Confirm the live feed resumes automatically.
 
 ---
 
-### Camera switching
+## Part 3 — Type B Semantic Hydration (M2)
 
-40. Change the camera using the selector in the header
-41. Confirm the slot grid clears and reloads for the new camera (new thumbnails, not the same frames)
-42. Confirm the live view in the video panel switches to the new camera feed
-43. Confirm **Play Recording** works on the new camera
+**20.** With zoom ≥ 5 minutes, look at the slot grid. Confirm some thumbnails have a **B** label or coloured indicator distinguishing them from A slots.
 
----
+**21.** In the timeline wheel (left panel), confirm B slots show a small icon (person, car, dog, etc.) to the right of the time label with a coloured dot beside it.
 
-### Edge cases
+**22.** Open **Debug**. In the Slot Detail table, confirm B rows show a numeric score (e.g. `42%`) not a dash.
 
-44. Select a camera that is unlikely to have recent recordings (pick one from the bottom of the list)
-45. Confirm the app does not crash — placeholder frames or mock images should appear, no JS errors
-46. Scroll the timeline far into the past (several hours) — confirm the app loads without errors
-47. Rapidly click **+** and **−** zoom buttons 10 times quickly — confirm no crash and no duplicate or mismatched slot batches when it settles
+**23.** Restart the core server on the host machine, then reload the page. Confirm B slots still appear within the first batch (not after a delay) — this proves startup hydration from SQLite is working.
 
 ---
 
-### Media service API checks (run these in the browser console via fetch)
+## Part 4 — MQTT Freshness (M3)
 
-Run each of these in the DevTools console. They test the Python media service directly.
+**24.** With the app loaded, confirm the freshness badge shows **live**.
 
-**Health check:**
+**25.** Walk in front of a camera. Within ~5 seconds, confirm one or more slots in the slot grid briefly show a **dirty** status indicator (yellow border or status text), then update to a new frame.
+- If no dirty slots appear → MQTT events are not reaching the server, or the event's timestamp falls outside the current viewport.
+
+---
+
+## Part 5 — Playback (M4)
+
+**26.** Scroll to a time slot that has a recording (a non-placeholder frame image). Click that row to move the cursor there.
+
+**27.** Click **Play Recording**. Confirm the video panel switches from the still image to a playing video.
+
+**28.** Watch the console for HLS errors. Confirm none appear.
+
+**29.** Watch the cursor for 10 seconds. Confirm it **advances** as the video plays — the center row of the timeline wheel should move toward PRESENT over time.
+
+**30.** Confirm the time readout in the playback controls updates while playing.
+
+**31.** Click **Pause**. Confirm the video freezes and the cursor stops moving. Confirm the playback badge reads **SCRUB REVIEW**.
+
+**32.** Click **Play Recording** again. Confirm the video resumes from where it paused (cursor does not jump back to the original start time).
+
+**33.** Scroll to a different timestamp, then click **Play Recording**. Confirm the video starts from the new position.
+
+---
+
+## Part 6 — Debug Overlay
+
+**34.** Click **Debug**. Confirm the overlay table shows all of these rows: Camera, Socket, Freshness, Playback, Scrubbing, Cursor, Range, Viewport, Slots, Playing, VOD URL, Preview.
+
+**35.** Scroll the timeline with Debug open. Confirm the Cursor and Viewport rows update in real time.
+
+**36.** Confirm the Slot Detail table (below the main table) shows columns: `#`, `Strategy`, `Score`, `Entity`, `Status`.
+
+**37.** Confirm B-strategy rows are visually distinct from A rows (different colour or highlight).
+
+---
+
+## Part 7 — Camera switching
+
+**38.** Change the camera using the header selector. Confirm the slot grid clears and reloads with new thumbnails.
+
+**39.** Confirm the live feed switches to the new camera.
+
+**40.** Confirm **Play Recording** works on the new camera.
+
+---
+
+## Part 8 — Edge cases
+
+**41.** Select the last camera in the list (likely low activity). Confirm no crash. Placeholder frames acceptable.
+
+**42.** Scroll the timeline several hours into the past. Confirm no crash and no JS errors.
+
+**43.** Rapidly click **+** and **−** 10 times in quick succession. Confirm no crash and no duplicate or mismatched slot batches once it settles.
+
+**44.** Refresh the page while a recording is playing. Confirm the app reloads cleanly into SCRUB_REVIEW state (not stuck in playing mode).
+
+---
+
+## Part 9 — API checks (run in DevTools console)
+
+Run these on the **public URL** (`https://frigatebird.pondhouse.cloud`) unless otherwise noted.
+If a check fails on public but passes on local (`http://192.168.50.207:4020`), the issue is the nginx proxy rule, not the service itself.
+
+**45.** Core server health — run in console:
+```javascript
+fetch('https://frigatebird.pondhouse.cloud/health')
+  .then(r => r.json()).then(console.log).catch(console.error)
+```
+Expect: `{"ok": true, "service": "core-server", ...}`
+
+**46.** Media service health:
 ```javascript
 fetch('https://frigatebird.pondhouse.cloud/api-media/health')
-  .then(r => r.json()).then(console.log)
+  .then(r => r.json()).then(console.log).catch(console.error)
 ```
-48. Confirm response includes `"ok": true` and `"frigate_reachable": true`
+Expect: `{"ok": true, "service": "media-service", "frigate_reachable": true}`
+- If returns HTML → nginx `/api-media/` proxy rule is missing
+- If `frigate_reachable: false` → Frigate on port 5000 is down
 
-**Preview strip** (replace CAMERA and timestamps with real values):
+**47.** Media service health — local direct (run this too, to isolate nginx vs service):
+```javascript
+fetch('http://192.168.50.207:4020/health')
+  .then(r => r.json()).then(console.log).catch(console.error)
+```
+Expect same as above. If this fails but the service is supposed to be running, the media service process itself is down.
+
+**48.** Preview strip:
 ```javascript
 fetch('https://frigatebird.pondhouse.cloud/api-media/preview/strip', {
   method: 'POST',
@@ -147,12 +229,12 @@ fetch('https://frigatebird.pondhouse.cloud/api-media/preview/strip', {
     end_time: Math.floor(Date.now()/1000) - 60,
     count: 12
   })
-}).then(r => r.json()).then(console.log)
+}).then(r => r.json()).then(d => { console.log(d); if(d.url) window.open('https://frigatebird.pondhouse.cloud' + d.url) })
+  .catch(console.error)
 ```
-49. Confirm response includes `"ok": true` and a `"url"` path ending in `.webp`
-50. Open the returned URL in a new tab — confirm it loads a wide filmstrip image (12 frames side by side)
+Expect: `{"ok": true, "url": "/media/preview/...webp", ...}`. A new tab should open showing a wide filmstrip image.
 
-**Clip prepare:**
+**49.** Clip prepare:
 ```javascript
 fetch('https://frigatebird.pondhouse.cloud/api-media/clip/prepare', {
   method: 'POST',
@@ -162,28 +244,39 @@ fetch('https://frigatebird.pondhouse.cloud/api-media/clip/prepare', {
     start_time: Math.floor(Date.now()/1000) - 300,
     end_time: Math.floor(Date.now()/1000) - 240
   })
-}).then(r => r.json()).then(console.log)
+}).then(r => r.json()).then(d => { console.log(d); if(d.clip_url) window.open('https://frigatebird.pondhouse.cloud' + d.clip_url) })
+  .catch(console.error)
 ```
-51. Confirm response includes `"ok": true`, `"status": "ready"`, and a `"clip_url"` path ending in `.mp4`
-52. Open the returned clip URL — confirm it plays as a video
+Expect: `{"ok": true, "clip_url": "/media/clips/...mp4", "status": "ready", ...}`. A new tab should open and the MP4 should play.
 
 ---
 
-### Final report
+## Part 10 — Environment comparison summary
 
-After completing all 52 checks, output a results table in this format:
+After completing all checks on both environments, fill in this comparison table:
 
-| # | Test | Result | Notes |
-|---|------|--------|-------|
-| 1 | No console errors on load | PASS | |
-| 2 | Socket badge: connected | PASS | |
-| ... | | | |
+| Check | Local (192.168.50.207:5173) | Public (frigatebird.pondhouse.cloud) |
+|---|---|---|
+| App loads | | |
+| Socket connects | | |
+| Freshness: live | | |
+| Slots load (60/60) | | |
+| Type B slots appear | | |
+| Live JPEG feed | | |
+| HLS playback | | |
+| Cursor advances | | |
+| Media service health | | |
+| Preview strip API | | |
+| Clip prepare API | | |
 
-Then write a short paragraph summarising:
-- Total PASS / FAIL / SKIP counts
-- Any patterns in failures (e.g. all API checks failed → likely a proxy config issue)
-- Recommended next steps for any failures
+Any item that is PASS locally but FAIL publicly points to a missing nginx proxy rule. Reference the infrastructure table at the top to identify which rule is needed.
 
 ---
 
-**Note on API paths:** The fetch URLs above assume nginx proxy manager is routing `/api-media/` to the Python media service on port 4020. If the proxy path differs on your setup, adjust accordingly. The core Socket.IO server is on port 4010 and the frontend on port 5173 — both proxied through nginx at the same domain.
+## Final report format
+
+Produce:
+1. The full numbered results table (both environments per item where tested)
+2. The environment comparison table above, filled in
+3. A diagnosis section: for each FAIL, one sentence on the root cause (code bug vs proxy config vs service down)
+4. A prioritised fix list — highest impact first

--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,13 @@
+# Frontend environment variables
+# Copy to .env.local for local overrides. Never commit .env.local.
+
+# Core server URL (Socket.IO).
+# LOCAL DEV: set to the direct port.
+# PRODUCTION (nginx): leave unset — the app connects to window.location.origin
+#   and nginx proxies /socket.io/ to localhost:4010.
+# VITE_CORE_URL=http://localhost:4010
+
+# Frigate NVR base URL (live JPEG feed).
+# LOCAL DEV: leave unset — defaults to http://{hostname}:5000.
+# PRODUCTION (nginx): set to the proxied path so the browser request stays HTTPS.
+# VITE_FRIGATE_URL=https://frigatebird.pondhouse.cloud/frigate

--- a/apps/frontend/src/components/VideoPlayer.jsx
+++ b/apps/frontend/src/components/VideoPlayer.jsx
@@ -1,7 +1,9 @@
 import { useRef, useEffect, useState } from 'react';
 import Hls from 'hls.js';
 
-const FRIGATE_URL = `http://${window.location.hostname}:5000`;
+// VITE_FRIGATE_URL lets nginx proxy Frigate's API over HTTPS.
+// Falls back to the direct port for local dev.
+const FRIGATE_URL = import.meta.env.VITE_FRIGATE_URL ?? `http://${window.location.hostname}:5000`;
 const LIVE_REFRESH_MS = 1000;
 
 export default function VideoPlayer({

--- a/apps/frontend/src/hooks/useSocket.js
+++ b/apps/frontend/src/hooks/useSocket.js
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 import { io } from 'socket.io-client';
 
-const CORE_SERVER_URL = `http://${window.location.hostname}:4010`;
+// When VITE_CORE_URL is set (local dev), connect directly to the core server.
+// When unset (production through nginx), connect to the same origin so nginx
+// can proxy /socket.io/ over the existing HTTPS connection — no mixed content.
+const CORE_SERVER_URL = import.meta.env.VITE_CORE_URL ?? window.location.origin;
 
 export function useSocket() {
   const [status, setStatus] = useState('disconnected');


### PR DESCRIPTION
## Summary

- **Mixed content fix**: `useSocket.js` now connects to `window.location.origin` when `VITE_CORE_URL` is unset, so Socket.IO works through nginx HTTPS without a mixed-content block
- **Frigate URL configurable**: `VideoPlayer.jsx` reads `VITE_FRIGATE_URL` env var so the live JPEG feed can be proxied over HTTPS
- **`.env.example`** added documenting both vars with local/production guidance
- **Claude Chrome test prompt** rewritten: tests both `http://192.168.50.207:5173` and `https://frigatebird.pondhouse.cloud` in parallel, reads source from GitHub, includes environment comparison table and nginx diagnosis logic

## Required nginx proxy rules (not in this PR — manual config)

```nginx
# Socket.IO — needs WebSocket upgrade headers
location /socket.io/ {
    proxy_pass http://localhost:4010/socket.io/;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
}

# Media service
location /api-media/ {
    proxy_pass http://localhost:4020/;
}

# Frigate live feed
location /frigate/ {
    proxy_pass http://localhost:5000/;
}
```

Then set `VITE_FRIGATE_URL=https://frigatebird.pondhouse.cloud/frigate` in `apps/frontend/.env.local` and restart Vite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)